### PR TITLE
Add LGTM.com code quality badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![GitHub license](https://img.shields.io/github/license/adobe/helix-cli.svg)](https://github.com/adobe/helix-cli/blob/master/LICENSE.txt)
 [![GitHub issues](https://img.shields.io/github/issues/adobe/helix-cli.svg)](https://github.com/adobe/helix-cli/issues)
 [![Greenkeeper badge](https://badges.greenkeeper.io/adobe/helix-cli.svg)](https://greenkeeper.io/)
+[![LGTM Code Quality Grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/adobe/helix-cli.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/adobe/helix-cli)
 
 The Helix Command Line Interface allows web developers to create, develop, and deploy digital experiences using Project Helix
 


### PR DESCRIPTION
Hi @trieloff! I noticed that you wiped out all of the LGTM.com alerts in https://github.com/adobe/helix-cli/pull/35 and enabled automatic code review for pull requests — cool :slightly_smiling_face:! Looking at your list of badges, I thought you might be interested in adding this 'A+' LGTM code quality badge. 

Feel free to ignore/close this PR if you'd rather stick to your current selection of badges!

(Full disclosure: I'm on the team that develops LGTM.com)