### PR TITLE
Use released OpenWhisk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "glob": "^7.1.2",
     "js-yaml": "^3.12.0",
     "object-hash": "^1.3.0",
-    "openwhisk": "https://github.com/trieloff/incubator-openwhisk-client-js.git",
+    "openwhisk": "3.16.0",
     "parcel-bundler": "^1.9.7",
     "request": "^2.87.0",
     "request-promise": "^4.2.2",


### PR DESCRIPTION
We've been using a patched version of the OpenWhisk client, but the changes have been released now, so that we can go back to the mainline version.

See apache/incubator-openwhisk-client-js#123

