### PR TITLE
Auto-Deployment (without Static Delivery Changes)

### DIFF
--- a/demos/full/config.yml
+++ b/demos/full/config.yml
@@ -1,0 +1,44 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:8-stretch
+    steps:
+        - checkout
+
+        # Download and cache dependencies
+        - restore_cache:
+            keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+
+        - run: 
+            name: Installing Dependencies
+            command: npm install 
+
+        - run:
+            name: Installing Helix CLI
+            command: npm install @adobe/helix-cli
+
+        - save_cache:
+            paths:
+                - node_modules
+            key: v1-dependencies-{{ checksum "package.json" }}
+
+        - run:
+            name: Building Templates
+            command: npx hlx build
+
+        - run: git diff
+
+        - run:
+            name: Deploying to Adobe I/O Runtime
+            command: npx hlx deploy --no-auto
+
+        - run:
+            name: Activate CDN
+            command: npx hlx strain
+
+        - run:
+            name: Test Performance
+            command: npx hlx perf

--- a/demos/simple/config.yml
+++ b/demos/simple/config.yml
@@ -1,0 +1,44 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:8-stretch
+    steps:
+        - checkout
+
+        # Download and cache dependencies
+        - restore_cache:
+            keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+
+        - run: 
+            name: Installing Dependencies
+            command: npm install 
+
+        - run:
+            name: Installing Helix CLI
+            command: npm install @adobe/helix-cli
+
+        - save_cache:
+            paths:
+                - node_modules
+            key: v1-dependencies-{{ checksum "package.json" }}
+
+        - run:
+            name: Building Templates
+            command: npx hlx build
+
+        - run: git diff
+
+        - run:
+            name: Deploying to Adobe I/O Runtime
+            command: npx hlx deploy --no-auto
+
+        - run:
+            name: Activate CDN
+            command: npx hlx strain
+
+        - run:
+            name: Test Performance
+            command: npx hlx perf

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -273,8 +273,6 @@ class DeployCommand {
 
     const follow = await request(followoptions);
 
-    console.log(this._fastly_auth, this._fastly_namespace);
-
     if (follow.first_build) {
       console.log('\nAuto-deployment started.');
       const envars = [];

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -247,7 +247,7 @@ class DeployCommand {
 
   async autoDeploy() {
     if (!(fs.existsSync(path.resolve(process.cwd(), '.circleci', 'config.yaml')) || fs.existsSync(path.resolve(process.cwd(), '.circleci', 'config.yml')))) {
-      throw new Error('Cannot automate deployment without .circleci/config.yaml');
+      throw new Error(`Cannot automate deployment without ${path.resolve(process.cwd(), '.circleci', 'config.yaml')}`);
     }
 
     const { owner, repo, ref } = GitUtils.getOriginURL();
@@ -273,43 +273,40 @@ class DeployCommand {
 
     const follow = await request(followoptions);
 
+    const envars = [];
+
+    if (this._fastly_namespace) {
+      envars.push(DeployCommand.setBuildVar('HLX_FASTLY_NAMESPACE', this._fastly_namespace, owner, repo, auth));
+    }
+    if (this._fastly_auth) {
+      envars.push(DeployCommand.setBuildVar('HLX_FASTLY_AUTH', this._fastly_auth, owner, repo, auth));
+    }
+
+    if (this._wsk_auth) {
+      envars.push(DeployCommand.setBuildVar('HLX_WSK_AUTH', this._wsk_auth, owner, repo, auth));
+    }
+
+    if (this._wsk_host) {
+      envars.push(DeployCommand.setBuildVar('HLX_WSK_HOST', this._wsk_host, owner, repo, auth));
+    }
+    if (this._wsk_namespace) {
+      envars.push(DeployCommand.setBuildVar('HLX_WSK_NAMESPACE', this._wsk_namespace, owner, repo, auth));
+    }
+    if (this._loggly_auth) {
+      envars.push(DeployCommand.setBuildVar('HLX_LOGGLY_AUTH', this._wsk_auth, owner, repo, auth));
+    }
+    if (this._loggly_host) {
+      envars.push(DeployCommand.setBuildVar('HLX_LOGGLY_HOST', this._loggly_host, owner, repo, auth));
+    }
+
+    await Promise.all(envars);
+
     if (follow.first_build) {
-      console.log('\nAuto-deployment started.');
-      const envars = [];
-
-      if (this._fastly_namespace) {
-        envars.push(DeployCommand.setBuildVar('HLX_FASTLY_NAMESPACE', this._fastly_namespace, owner, repo, auth));
-      }
-      if (this._fastly_auth) {
-        envars.push(DeployCommand.setBuildVar('HLX_FASTLY_AUTH', this._fastly_auth, owner, repo, auth));
-      }
-
-      if (this._wsk_auth) {
-        envars.push(DeployCommand.setBuildVar('HLX_WSK_AUTH', this._wsk_auth, owner, repo, auth));
-      }
-
-      if (this._wsk_host) {
-        envars.push(DeployCommand.setBuildVar('HLX_WSK_HOST', this._wsk_host, owner, repo, auth));
-      }
-      if (this._wsk_namespace) {
-        envars.push(DeployCommand.setBuildVar('HLX_WSK_NAMESPACE', this._wsk_namespace, owner, repo, auth));
-      }
-      if (this._loggly_auth) {
-        envars.push(DeployCommand.setBuildVar('HLX_LOGGLY_AUTH', this._wsk_auth, owner, repo, auth));
-      }
-      if (this._loggly_host) {
-        envars.push(DeployCommand.setBuildVar('HLX_LOGGLY_HOST', this._loggly_host, owner, repo, auth));
-      }
-
-      try {
-        await Promise.all(envars);
-        console.log('Configuration finished. Go to');
-        console.log(`${chalk.grey(`https://circleci.com/gh/${owner}/${repo}/edit`)} for build settings or`);
-        console.log(`${chalk.grey(`https://circleci.com/gh/${owner}/${repo}`)} for build status.`);
-      } catch (e) {
-        console.error('Error setting build environment variables');
-        throw e;
-      }
+      console.log('\nAuto-deployment started.');    
+      console.log('Configuration finished. Go to');
+      console.log(`${chalk.grey(`https://circleci.com/gh/${owner}/${repo}/edit`)} for build settings or`);
+      console.log(`${chalk.grey(`https://circleci.com/gh/${owner}/${repo}`)} for build status.`);
+  
     } else {
       console.log('\nAuto-deployment already set up. Triggering a new build.');
 

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -36,6 +36,7 @@ const DISTRIBUTORS = {
 class DeployCommand {
   constructor() {
     this._enableAuto = true;
+    this._circleciAuth = null;
     this._wsk_auth = null;
     this._wsk_namespace = null;
     this._wsk_host = null;
@@ -68,6 +69,11 @@ class DeployCommand {
 
   withEnableAuto(value) {
     this._enableAuto = value;
+    return this;
+  }
+
+  withCircleciAuth(value) {
+    this._circleciAuth = value;
     return this;
   }
 

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -302,11 +302,10 @@ class DeployCommand {
     await Promise.all(envars);
 
     if (follow.first_build) {
-      console.log('\nAuto-deployment started.');    
+      console.log('\nAuto-deployment started.');
       console.log('Configuration finished. Go to');
       console.log(`${chalk.grey(`https://circleci.com/gh/${owner}/${repo}/edit`)} for build settings or`);
       console.log(`${chalk.grey(`https://circleci.com/gh/${owner}/${repo}`)} for build status.`);
-  
     } else {
       console.log('\nAuto-deployment already set up. Triggering a new build.');
 

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -231,6 +231,10 @@ class DeployCommand {
   }
 
   async autoDeploy() {
+    if (!(fs.existsSync(path.resolve(process.cwd(), '.circleci', 'config.yaml')) || fs.existsSync(path.resolve(process.cwd(), '.circleci', 'config.yml')))) {
+      throw new Error('Cannot automate deployment without .circleci/config.yaml');
+    }
+
     const { owner, repo } = GitUtils.getOriginURL();
 
     const auth = {

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -221,7 +221,7 @@ class DeployCommand {
     });
   }
 
-  static setDeployVarOptions(name, value, owner, repo, auth) {
+  static getBuildVarOptions(name, value, auth, owner, repo) {
     const body = JSON.stringify({
       name,
       value,
@@ -237,6 +237,11 @@ class DeployCommand {
       },
       body,
     };
+    return options;
+  }
+
+  static setBuildVar(name, value, owner, repo, auth) {
+    const options = DeployCommand.getBuildVarOptions(name, value, auth, owner, repo);
     return request(options);
   }
 
@@ -275,27 +280,27 @@ class DeployCommand {
       const envars = [];
 
       if (this._fastly_namespace) {
-        envars.push(DeployCommand.setDeployVarOptions('HLX_FASTLY_NAMESPACE', this._fastly_namespace, owner, repo, auth));
+        envars.push(DeployCommand.setBuildVar('HLX_FASTLY_NAMESPACE', this._fastly_namespace, owner, repo, auth));
       }
       if (this._fastly_auth) {
-        envars.push(DeployCommand.setDeployVarOptions('HLX_FASTLY_AUTH', this._fastly_auth, owner, repo, auth));
+        envars.push(DeployCommand.setBuildVar('HLX_FASTLY_AUTH', this._fastly_auth, owner, repo, auth));
       }
 
       if (this._wsk_auth) {
-        envars.push(DeployCommand.setDeployVarOptions('HLX_WSK_AUTH', this._wsk_auth, owner, repo, auth));
+        envars.push(DeployCommand.setBuildVar('HLX_WSK_AUTH', this._wsk_auth, owner, repo, auth));
       }
 
       if (this._wsk_host) {
-        envars.push(DeployCommand.setDeployVarOptions('HLX_WSK_HOST', this._wsk_host, owner, repo, auth));
+        envars.push(DeployCommand.setBuildVar('HLX_WSK_HOST', this._wsk_host, owner, repo, auth));
       }
       if (this._wsk_namespace) {
-        envars.push(DeployCommand.setDeployVarOptions('HLX_WSK_NAMESPACE', this._wsk_namespace, owner, repo, auth));
+        envars.push(DeployCommand.setBuildVar('HLX_WSK_NAMESPACE', this._wsk_namespace, owner, repo, auth));
       }
       if (this._loggly_auth) {
-        envars.push(DeployCommand.setDeployVarOptions('HLX_LOGGLY_AUTH', this._wsk_auth, owner, repo, auth));
+        envars.push(DeployCommand.setBuildVar('HLX_LOGGLY_AUTH', this._wsk_auth, owner, repo, auth));
       }
       if (this._loggly_host) {
-        envars.push(DeployCommand.setDeployVarOptions('HLX_LOGGLY_HOST', this._loggly_host, owner, repo, auth));
+        envars.push(DeployCommand.setBuildVar('HLX_LOGGLY_HOST', this._loggly_host, owner, repo, auth));
       }
 
       try {
@@ -323,7 +328,6 @@ class DeployCommand {
       };
 
       const triggered = await request(triggeroptions);
-
 
 
       console.log(`Go to ${chalk.grey(`${triggered.build_url}`)} for build status.`);

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -79,6 +79,16 @@ class DeployCommand {
     return this;
   }
 
+  withFastlyAuth(value) {
+    this._fastly_auth = value;
+    return this;
+  }
+
+  withFastlyNamespace(value) {
+    this._fastly_namespace = value;
+    return this;
+  }
+
   withWskHost(value) {
     this._wsk_host = value;
     return this;
@@ -235,7 +245,7 @@ class DeployCommand {
       throw new Error('Cannot automate deployment without .circleci/config.yaml');
     }
 
-    const { owner, repo } = GitUtils.getOriginURL();
+    const { owner, repo, ref } = GitUtils.getOriginURL();
 
     const auth = {
       username: this._circleciAuth,
@@ -258,7 +268,9 @@ class DeployCommand {
 
     const follow = await request(followoptions);
 
-    if (!follow.first_build) {
+    console.log(this._fastly_auth, this._fastly_namespace);
+
+    if (follow.first_build) {
       console.log('\nAuto-deployment started.');
       const envars = [];
 
@@ -296,9 +308,25 @@ class DeployCommand {
         throw e;
       }
     } else {
-      console.log('\nAuto-deployment already set up. Go to');
-      console.log(`${chalk.grey(`https://circleci.com/gh/${owner}/${repo}`)} for build status or`);
-      console.log(`${chalk.grey(`https://circleci.com/gh/${owner}/${repo}/edit`)} for build settings`);
+      console.log('\nAuto-deployment already set up. Triggering a new build.');
+
+      const triggeroptions = {
+        method: 'POST',
+        json: true,
+        auth,
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'User-Agent': 'helix-cli',
+        },
+        uri: `https://circleci.com/api/v1.1/project/github/${owner}/${repo}/tree/${ref}`,
+      };
+
+      const triggered = await request(triggeroptions);
+
+
+
+      console.log(`Go to ${chalk.grey(`${triggered.build_url}`)} for build status.`);
     }
   }
 

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -20,7 +20,6 @@ const ow = require('openwhisk');
 const glob = require('glob');
 const path = require('path');
 const fs = require('fs-extra');
-const chalk = require('chalk');
 const yaml = require('js-yaml');
 const archiver = require('archiver');
 const GitUrl = require('@adobe/petridish/src/GitUrl');

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -106,7 +106,36 @@ module.exports = function deploy() {
         }, {}))
         .group(['auto', 'wsk-auth', 'wsk-namespace', 'default', 'dirty'], 'Deployment Options')
         .group(['wsk-host', 'loggly-host', 'loggly-auth', 'target', 'docker', 'prefix', 'content'], 'Advanced Options')
-        .check(args => (args.auto <= !!args.circleciAuth ? true : new Error('auto-deployment requires --circleci-auth')))
+        .check((args) => {
+          if (!args.auto) {
+            // single-shot deployment is easy
+            return true;
+          }
+          const message = 'Auto-deployment requires: ';
+          const missing = [];
+          if (!args.circleciAuth) {
+            missing.push('--circleci-auth');
+          }
+          if (!args.fastlyAuth) {
+            missing.push('--fastly-auth');
+          }
+          if (!args.fastlyAuth) {
+            missing.push('--fastly-namespace');
+          }
+          if (!args.wskAuth) {
+            missing.push('--wsk-auth');
+          }
+          if (!args.wskNamespace) {
+            missing.push('--wsk-namespace');
+          }
+          if (!args.wskHost) {
+            missing.push('--wsk-host');
+          }
+          if (missing.length === 0) {
+            return true;
+          }
+          return new Error(message + missing.join(', '));
+        })
         .help();
     },
     handler: async (argv) => {

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -55,6 +55,11 @@ module.exports = function deploy() {
           type: 'string',
           default: '',
         })
+        .option('circleci-auth', {
+          describe: 'API Key for CircleCI API ($HLX_CIRCLECI_AUTH)',
+          type: 'string',
+          default: '',
+        })
         .option('target', {
           alias: 'o',
           default: '.hlx/build',
@@ -101,6 +106,7 @@ module.exports = function deploy() {
         }, {}))
         .group(['auto', 'wsk-auth', 'wsk-namespace', 'default', 'dirty'], 'Deployment Options')
         .group(['wsk-host', 'loggly-host', 'loggly-auth', 'target', 'docker', 'prefix', 'content'], 'Advanced Options')
+        .check(args => (args.auto <= !!args.circleciAuth ? true : new Error('auto-deployment requires --circleci-auth')))
         .help();
     },
     handler: async (argv) => {
@@ -125,6 +131,7 @@ module.exports = function deploy() {
         .withDryRun(argv.dryRun)
         .withContent(argv.content)
         .withStaticContent(argv.staticContent)
+        .withCircleciAuth(argv.circleciAuth)
         .run();
     },
 

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -26,6 +26,9 @@ module.exports = function deploy() {
     builder: (yargs) => {
       // eslint-disable-next-line global-require
       const DeployCommand = require('./deploy.cmd'); // lazy load the handler to speed up execution time
+      // eslint-disable-next-line global-require
+      const GitUtils = require('./gitutils'); // lazy load the handler to speed up execution time
+
       deployCommon(yargs)
         .option('auto', {
           describe: 'Enable auto-deployment',
@@ -65,7 +68,7 @@ module.exports = function deploy() {
         .option('prefix', {
           alias: 'p',
           describe: 'Prefix for the deployed action name.',
-          default: `${DeployCommand.getRepository()}--${DeployCommand.getBranchFlag()}--`,
+          default: `${GitUtils.getRepository()}--${GitUtils.getBranchFlag()}--`,
         })
         .option('default', {
           describe: 'Adds a default parameter to the function',

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -119,7 +119,7 @@ module.exports = function deploy() {
           if (!args.fastlyAuth) {
             missing.push('--fastly-auth');
           }
-          if (!args.fastlyAuth) {
+          if (!args.fastlyNamespace) {
             missing.push('--fastly-namespace');
           }
           if (!args.wskAuth) {
@@ -161,6 +161,8 @@ module.exports = function deploy() {
         .withContent(argv.content)
         .withStaticContent(argv.staticContent)
         .withCircleciAuth(argv.circleciAuth)
+        .withFastlyAuth(argv.fastlyAuth)
+        .withFastlyNamespace(argv.fastlyNamespace)
         .run();
     },
 

--- a/src/gitutils.js
+++ b/src/gitutils.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint no-console: off */
+
+const $ = require('shelljs');
+const path = require('path');
+const GitUrl = require('@adobe/petridish/src/GitUrl');
+
+class GitUtils {
+  static isDirty() {
+    return $
+      .exec('git status --porcelain', {
+        silent: true,
+      })
+      .stdout.replace(/\n/g, '')
+      .replace(/[\W]/g, '-').length;
+  }
+
+  static getBranch() {
+    const rev = $
+      .exec('git rev-parse HEAD', {
+        silent: true,
+      })
+      .stdout.replace(/\n/g, '')
+      .replace(/[\W]/g, '-');
+
+    const tag = $
+      .exec(`git name-rev --tags --name-only ${rev}`, {
+        silent: true,
+      })
+      .stdout.replace(/\n/g, '')
+      .replace(/[\W]/g, '-');
+
+    const branchname = $
+      .exec('git rev-parse --abbrev-ref HEAD', {
+        silent: true,
+      })
+      .stdout.replace(/\n/g, '')
+      .replace(/[\W]/g, '-');
+
+    return tag !== 'undefined' ? tag : branchname;
+  }
+
+
+  static getBranchFlag() {
+    return GitUtils.isDirty() ? 'dirty' : GitUtils.getBranch();
+  }
+
+
+  static getRepository() {
+    const repo = GitUtils.getOrigin()
+      .replace(/[\W]/g, '-');
+    if (repo !== '') {
+      return repo;
+    }
+    return `local--${path.basename(process.cwd())}`;
+  }
+
+  static getOrigin() {
+    const origin = $.exec('git config --get remote.origin.url', {
+      silent: true,
+    }).stdout.replace(/\n/g, '');
+    return origin;
+  }
+
+  static getOriginURL() {
+    return new GitUrl(GitUtils.getOrigin());
+  }
+}
+
+module.exports = GitUtils;

--- a/src/strain.cmd.js
+++ b/src/strain.cmd.js
@@ -21,7 +21,6 @@ const URI = require('uri-js');
 const { toBase64 } = require('request/lib/helpers');
 const strainconfig = require('./strain-config-utils');
 const include = require('./include-util');
-const GitUtils = require('./gitutils');
 
 const HELIX_VCL_DEFAULT_FILE = path.resolve(__dirname, '../layouts/fastly/helix.vcl');
 
@@ -57,7 +56,6 @@ class StrainCommand {
       strain_github_static_repos: null,
       strain_github_static_owners: null,
       strain_github_static_refs: null,
-      strain_github_static_magic: null,
       strain_index_files: null,
     };
 
@@ -581,22 +579,12 @@ class StrainCommand {
       makeStrainjob('strain_root_paths', strain.name, strain.content.root, '🌲  Set content root');
 
       // static
-      if (strain.static) {
-        // if there is a static configuration in the strain, take it
-        makeStrainjob('github_static_repos', strain.name, strain.static.repo, '🌳  Set static repo');
-        makeStrainjob('github_static_owners', strain.name, strain.static.owner, '🏢  Set static owner');
-        makeStrainjob('github_static_refs', strain.name, strain.static.ref, '🏷  Set static ref');
-        makeStrainjob('github_static_magic', strain.name, strain.static.magic ? 'true' : 'false', strain.name, strain.static.magic ? '🔮  Enable magic' : '⚽️  Disable magic');
+      if (strain.githubStatic) {
+        makeStrainjob('github_static_repos', strain.name, strain.githubStatic.repo, '🌳  Set static repo');
+        makeStrainjob('github_static_owners', strain.name, strain.githubStatic.owner, '🏢  Set static owner');
+        makeStrainjob('github_static_refs', strain.name, strain.githubStatic.ref, '🏷  Set static ref');
       } else {
-        // otherwise just use the current repo
-        const origin = GitUtils.getOriginURL();
-        console.log('=========STATIC=========');
-        console.log(origin);
-        makeStrainjob('github_static_repos', strain.name, origin.repo, '🌳  Set static repo');
-        makeStrainjob('github_static_owners', strain.name, origin.owner, '🏢  Set static owner');
-        // TODO: replace ref with sha for better performance and lower risk of hitting rate limits
-        makeStrainjob('github_static_refs', strain.name, origin.ref, '🏷  Set static ref');
-        makeStrainjob('github_static_magic', 'false', strain.name, '⚽️  Disable magic');
+        makeStrainjob('github_static_refs', strain.name, '', '🏷  Clearing static ref');
       }
       return strain;
     });

--- a/test/fixtures/circleci.com-443/153598406333081578
+++ b/test/fixtures/circleci.com-443/153598406333081578
@@ -1,0 +1,18 @@
+POST /api/v1.1/project/github/trieloff/helix-helpx/follow
+
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+date: Mon, 03 Sep 2018 14:14:23 GMT
+server: nginx
+set-cookie: ring-session=hJR6A99f2wjTByx3oQaJMdYa8WIAYp01vHmifhXbcJ26wEhzz8uplwHcERjVW5snrUqDIYrXKkXUMIakAPIWsCrIlPueldYKDtEQRVjNzNijtlOIcIm3faKLWE909IhCIh5xwsrMmP5aw1%2FWU1HH9xlApnYcH4R%2FZfhkE9kUreQ5X29fFK5DRPzvXjeG2xsM22do%2FdD9MCNkQiQxqmYxBi%2FEUxPz4L7cCbPS3QJHTow%3D--nOaLk%2BUrlrfmP%2FFeK1AKKQpzvNmdJwEDH3C2SEdxfLM%3D;Path=/;HttpOnly;Expires=Tue, 03 Sep 2019 11:10:07 +0000;Max-Age=1209600;Secure
+strict-transport-security: max-age=15724800
+x-circleci-identity: circle-www-api-v1-59d9c6d85b-nzv57
+x-circleci-scopes: :write-settings, :view-builds, :read-settings, :trigger-builds, :all, :status, :none
+x-client-trace-id: 
+x-frame-options: DENY
+x-request-id: 8febfdfc-a64e-4209-99ef-34bcc151500c
+x-route: /follow
+content-length: 54
+connection: Close
+
+{"following":true,"workflow":false,"first_build":null}

--- a/test/fixtures/circleci.com-443/153598406382587280
+++ b/test/fixtures/circleci.com-443/153598406382587280
@@ -1,0 +1,20 @@
+POST /api/v1.1/project/github/trieloff/helix-helpx/envvar
+body: {\"name\":\"HLX_WSK_NAMESPACE\",\"value\":\"hlx\"}
+
+HTTP/1.1 201 Created
+content-type: application/json; charset=utf-8
+date: Mon, 03 Sep 2018 14:14:23 GMT
+location: https://circleci.com/api/v1.1/project/github/trieloff/helix-helpx/envvar/HLX_WSK_NAMESPACE
+server: nginx
+set-cookie: ring-session=cVvNFzDEwwc%2F2en1yoaQRe2X7F6%2BcycD%2FSNracq%2B1TUe5X21I2BOzS3XaRIheZEbzTrg8rQtw1wk2DkRI2FW4Mmt2Ks9tQyoUiYy76DEcL1qX%2BDUpHkSJT2V2knJMh1YYU7aKjJqHic7wbFdr7bd7jvorT1%2BPuxDGrvEEY%2FryuycMkxWQIq9r7N126cF8kCrbVhExF%2FYtAWemwWhaLdaNauC5rqFE7cw6Rl4sWCfgW0%3D--PdA%2BkWwiesAuWmKDIj2BkKFSkx2iP7yx%2BM12zE8xBpI%3D;Path=/;HttpOnly;Expires=Tue, 03 Sep 2019 11:03:37 +0000;Max-Age=1209600;Secure
+strict-transport-security: max-age=15724800
+x-circleci-identity: circle-www-api-v1-59d9c6d85b-t88hr
+x-circleci-scopes: :write-settings, :view-builds, :read-settings, :trigger-builds, :all, :status, :none
+x-client-trace-id: 
+x-frame-options: DENY
+x-request-id: 8d2beb6d-f4e1-476d-9472-5d34588993a1
+x-route: /envvar
+content-length: 44
+connection: Close
+
+{"name":"HLX_WSK_NAMESPACE","value":"xxxxx"}

--- a/test/fixtures/circleci.com-443/153598406382939984
+++ b/test/fixtures/circleci.com-443/153598406382939984
@@ -1,0 +1,20 @@
+POST /api/v1.1/project/github/trieloff/helix-helpx/envvar
+body: {\"name\":\"HLX_WSK_AUTH\",\"value\":\"secret-key\"}
+
+HTTP/1.1 201 Created
+content-type: application/json; charset=utf-8
+date: Mon, 03 Sep 2018 14:14:23 GMT
+location: https://circleci.com/api/v1.1/project/github/trieloff/helix-helpx/envvar/HLX_WSK_AUTH
+server: nginx
+set-cookie: ring-session=61tRQd05T1dEJJurK15YwPMdoGbAB6GN%2Fb5ZLgf1DzhzJv27y8wYdqD6yJFgAna2t4zTxwhB7fEov%2FY6sQGpgLs6HsWYaJqVRwn1eNml72sheHEMA26Wydm%2B4hd8Bsn3dnbya1BeQfrN7q4KM%2Bw4nVmBq3aYKoYmbBDWUS256Y9IW2QCPHppoTtE1hGFsW%2F5kwKcL37gRQqzc8UkmZe3VLpi9vRbHMzPm0KuodTIGL4%3D--%2BD1lpOdVeCMMCVkXbin0U6VhZNUFZaiP4IIY1Zx9UBo%3D;Path=/;HttpOnly;Expires=Tue, 03 Sep 2019 11:10:00 +0000;Max-Age=1209600;Secure
+strict-transport-security: max-age=15724800
+x-circleci-identity: circle-www-api-v1-59d9c6d85b-pj5lt
+x-circleci-scopes: :write-settings, :view-builds, :read-settings, :trigger-builds, :all, :status, :none
+x-client-trace-id: 
+x-frame-options: DENY
+x-request-id: 105ab6d9-0148-4dfe-82b1-1ad14b4b1076
+x-route: /envvar
+content-length: 42
+connection: Close
+
+{"name":"HLX_WSK_AUTH","value":"xxxx-key"}

--- a/test/fixtures/circleci.com-443/153598406383158374
+++ b/test/fixtures/circleci.com-443/153598406383158374
@@ -1,0 +1,20 @@
+POST /api/v1.1/project/github/trieloff/helix-helpx/envvar
+body: {\"name\":\"HLX_WSK_HOST\",\"value\":\"runtime.adobe.io\"}
+
+HTTP/1.1 201 Created
+content-type: application/json; charset=utf-8
+date: Mon, 03 Sep 2018 14:14:23 GMT
+location: https://circleci.com/api/v1.1/project/github/trieloff/helix-helpx/envvar/HLX_WSK_HOST
+server: nginx
+set-cookie: ring-session=F92fhtUyPqwZMcQzDYwq32SAW4nEWV%2BHzaetSgpVOqClbtCore7dP2opMO%2BbH9SP1rO0lklQObYs3POfP9upZ5KM86eW8fmvKqgZY0MFgL9YYQ1jslPopE5jEk1kb%2B2BAqeStb7hmYLDyiE5Rf9K4Wf32FgzAt7mL4wX2JktWe24SUTY3KA%2FWj7UdxWAGSGXcT2k5gSVJREsIiyN7rbx%2BQj3%2BNxntEGdBM8tkMHUazA%3D--rMHWlLp0KR1sBD04YWd9nqbacQ9tebcg3U0iYRHtPRw%3D;Path=/;HttpOnly;Expires=Tue, 03 Sep 2019 11:13:07 +0000;Max-Age=1209600;Secure
+strict-transport-security: max-age=15724800
+x-circleci-identity: circle-www-api-v1-59d9c6d85b-5pst4
+x-circleci-scopes: :write-settings, :view-builds, :read-settings, :trigger-builds, :all, :status, :none
+x-client-trace-id: 
+x-frame-options: DENY
+x-request-id: f630342f-00b5-4cce-a3e6-35bf1e4d4bff
+x-route: /envvar
+content-length: 42
+connection: Close
+
+{"name":"HLX_WSK_HOST","value":"xxxxe.io"}

--- a/test/fixtures/circleci.com-443/153598406457647011
+++ b/test/fixtures/circleci.com-443/153598406457647011
@@ -1,0 +1,19 @@
+POST /api/v1.1/project/github/trieloff/helix-helpx/tree/master
+
+HTTP/1.1 201 Created
+content-type: application/json; charset=utf-8
+date: Mon, 03 Sep 2018 14:14:24 GMT
+location: https://circleci.com/api/v1.1/project/github/trieloff/helix-helpx/18
+server: nginx
+set-cookie: ring-session=uU6SfttX8lFJl3kVtt1zoEwNpqH4aY5%2FUpTwyTawwsSSKTAQgnwPDb9YKV2dSUeG0nWI%2FdXNqwruOEUxps6NfmJViV%2FljmSnaaHdqj9nRtItZZKBp41dQWRBStMV10RdigB2LGc%2FGje4XDxn5bFKtDeLU3LqI%2BYV9NYavRxPcSBIu%2BYRsTfTZujmlhZpoYg0p8xXSXlGCOs%2BdlJUbfJY4Ke5C1G%2BsqPQLPApmgOJ82s%3D--AO0d5A%2Fzl3f8xcOrljSKPnxW524F0SiS3wACc9lPHUg%3D;Path=/;HttpOnly;Expires=Tue, 03 Sep 2019 11:10:07 +0000;Max-Age=1209600;Secure
+strict-transport-security: max-age=15724800
+x-circleci-identity: circle-www-api-v1-59d9c6d85b-nzv57
+x-circleci-scopes: :write-settings, :view-builds, :read-settings, :trigger-builds, :all, :status, :none
+x-client-trace-id: 
+x-frame-options: DENY
+x-request-id: 5b7c17bc-ef20-4c97-b01c-2e290bee1e57
+x-route: /tree/:branch, :branch, [^,;?]+
+content-length: 2373
+connection: Close
+
+{"compare":null,"previous_successful_build":null,"build_parameters":{},"oss":true,"committer_date":null,"body":null,"usage_queued_at":"2018-09-03T14:14:24.487Z","fail_reason":null,"retry_of":null,"reponame":"helix-helpx","ssh_users":[],"build_url":"https://circleci.com/gh/trieloff/helix-helpx/18","parallel":1,"failed":null,"branch":"master","username":"trieloff","author_date":null,"why":"api","user":{"is_user":true,"login":"trieloff","avatar_url":"https://avatars3.githubusercontent.com/u/39613?v=4","name":"Lars Trieloff","vcs_type":"github","id":39613},"vcs_revision":"012908e61f3eb61ef0545c8900968377b4c04111","vcs_tag":null,"build_num":18,"infrastructure_fail":false,"committer_email":null,"previous":{"build_num":17,"status":"failed","build_time_millis":52834},"status":"not_running","committer_name":null,"retries":null,"subject":null,"vcs_type":"github","timedout":false,"dont_build":null,"lifecycle":"not_running","no_dependency_cache":false,"stop_time":null,"ssh_disabled":true,"build_time_millis":null,"picard":null,"circle_yml":{"string":"version: 2\njobs:\n  build:\n    docker:\n      # specify the version you desire here\n      - image: circleci/node:8-stretch\n    steps:\n        - checkout\n\n        # Download and cache dependencies\n        - restore_cache:\n            keys:\n            - v1-dependencies-{{ checksum \"package.json\" }}\n\n        - run: \n            name: Installing Dependencies\n            command: npm install \n\n        - run:\n            name: Installing Helix CLI\n            command: npm install @adobe/helix-cli\n\n        - save_cache:\n            paths:\n                - node_modules\n            key: v1-dependencies-{{ checksum \"package.json\" }}\n\n        - run:\n            name: Building Templates\n            command: npx hlx build\n\n        - run: git diff\n\n        - run:\n            name: Deploying to Adobe I/O Runtime\n            command: npx hlx deploy --no-auto\n\n        - run:\n            name: Activate CDN\n            command: npx hlx strain\n\n        - run:\n            name: Test Performance\n            command: npx hlx perf\n"},"messages":[],"is_first_green_build":false,"job_name":null,"start_time":null,"canceler":null,"platform":"2.0","outcome":null,"vcs_url":"https://github.com/trieloff/helix-helpx","author_name":null,"node":null,"canceled":false,"author_email":null}

--- a/test/fixtures/circleci.com-443/153598811993548716
+++ b/test/fixtures/circleci.com-443/153598811993548716
@@ -1,0 +1,23 @@
+POST /api/v1.1/project/github/trieloff/helix-helpx/envvar
+content-type: application/json
+accept: application/json
+host: circleci.com
+body: {\"name\":\"HLX_FASTLY_AUTH\",\"value\":\"nope\"}
+
+HTTP/1.1 201 Created
+content-type: application/json; charset=utf-8
+date: Mon, 03 Sep 2018 15:21:59 GMT
+location: https://circleci.com/api/v1.1/project/github/trieloff/helix-helpx/envvar/HLX_FASTLY_AUTH
+server: nginx
+set-cookie: ring-session=h8A2VC3kXvEkMstogMWkq3mRizVjp1Z1DBWsZ21WGTmc%2BEiYudyyRm9lNFutLdSkHgo3x8H1XvJXhZU1dwfen6cNoNkc6bBgNt58cz4XlyVJsex0Z9X2tggdzUYRMVdSYf4lL8dZENuNxxRJGcNjVrnKqr9LEffk8s%2Fja523g5WJa44GW62BTvmIn9kxOkO8KJsGMXeP%2FrFkY0NKw%2Bhoge2NL1Wgo8rPI%2FlNEz1%2Bz8U%3D--Tyhy%2Bpv2MDIVaqRuIsoL87ICK2ucjXhrzKc%2BRGvwD6s%3D;Path=/;HttpOnly;Expires=Tue, 03 Sep 2019 11:09:50 +0000;Max-Age=1209600;Secure
+strict-transport-security: max-age=15724800
+x-circleci-identity: circle-www-api-v1-59d9c6d85b-sn8pr
+x-circleci-scopes: :write-settings, :view-builds, :read-settings, :trigger-builds, :all, :status, :none
+x-client-trace-id: 
+x-frame-options: DENY
+x-request-id: f72f037f-3c21-4bed-8a6e-10c193e1e993
+x-route: /envvar
+content-length: 43
+connection: Close
+
+{"name":"HLX_FASTLY_AUTH","value":"xxxxpe"}

--- a/test/fixtures/circleci.com-443/153598811993739328
+++ b/test/fixtures/circleci.com-443/153598811993739328
@@ -1,0 +1,23 @@
+POST /api/v1.1/project/github/trieloff/helix-helpx/envvar
+content-type: application/json
+accept: application/json
+host: circleci.com
+body: {\"name\":\"HLX_FASTLY_NAMESPACE\",\"value\":\"justtesting\"}
+
+HTTP/1.1 201 Created
+content-type: application/json; charset=utf-8
+date: Mon, 03 Sep 2018 15:21:59 GMT
+location: https://circleci.com/api/v1.1/project/github/trieloff/helix-helpx/envvar/HLX_FASTLY_NAMESPACE
+server: nginx
+set-cookie: ring-session=%2F6bv4Pa3bNpcO4K01dyzAanFpw1BCpDzfYL2gKOmHl49wlfYD8m5il5JStirYKull35IPNF3gjnV3hWfuK0m8Dr%2FWFWxKvPFl6krNJgGJYgAMEre0NV1MELA%2Bj9Us1D40HDOcj3slFsfpj8WESJesGZEzAvlUR4qGyi1SlP2r0p5odtMbFbfre%2F69ObXxm9wmrxrN31PYUCsdUxTGzRR8rd%2F019cDpzxLKyTVT3GRTk%3D--7XPYVhK3xFp5mmDc8TkDeb%2F1U%2FJCkIeWyaRSaSLxC6o%3D;Path=/;HttpOnly;Expires=Tue, 03 Sep 2019 11:10:14 +0000;Max-Age=1209600;Secure
+strict-transport-security: max-age=15724800
+x-circleci-identity: circle-www-api-v1-59d9c6d85b-vcrmc
+x-circleci-scopes: :write-settings, :view-builds, :read-settings, :trigger-builds, :all, :status, :none
+x-client-trace-id: 
+x-frame-options: DENY
+x-request-id: 8a9982f0-226a-4781-8346-19db886e90ec
+x-route: /envvar
+content-length: 50
+connection: Close
+
+{"name":"HLX_FASTLY_NAMESPACE","value":"xxxxting"}

--- a/test/testBlankRemoteDeploy.js
+++ b/test/testBlankRemoteDeploy.js
@@ -45,7 +45,6 @@ describe('Test Deployment in Empty Project', () => {
 
   it('Get function name', () => {
     // eslint-disable-next-line global-require
-    const DeployCommand = require('../src/deploy.cmd');
     assert.notEqual('', GitUtils.getRepository());
     assert.equal('local--pulvillar-pantograph', GitUtils.getRepository());
   });

--- a/test/testBlankRemoteDeploy.js
+++ b/test/testBlankRemoteDeploy.js
@@ -17,6 +17,7 @@ const path = require('path');
 const fse = require('fs-extra');
 const Replay = require('replay');
 const DemoCommand = require('../src/demo.cmd');
+const GitUtils = require('../src/gitutils');
 
 const TEST_DIR = path.resolve(__dirname, 'tmp');
 const PROJECT_NAME = 'pulvillar-pantograph';
@@ -45,8 +46,8 @@ describe('Test Deployment in Empty Project', () => {
   it('Get function name', () => {
     // eslint-disable-next-line global-require
     const DeployCommand = require('../src/deploy.cmd');
-    assert.notEqual('', DeployCommand.getRepository());
-    assert.equal('local--pulvillar-pantograph', DeployCommand.getRepository());
+    assert.notEqual('', GitUtils.getRepository());
+    assert.equal('local--pulvillar-pantograph', GitUtils.getRepository());
   });
 
   afterEach('Reset working directory', function after() {

--- a/test/testBlankRemoteDeploy.js
+++ b/test/testBlankRemoteDeploy.js
@@ -51,7 +51,7 @@ describe('Test Deployment in Empty Project', () => {
   });
 
   afterEach('Reset working directory', function after() {
-    this.timeout(5000);
+    this.timeout(15000);
     process.chdir(pwd);
     fse.removeSync(TEST_DIR);
   });

--- a/test/testDeployCli.js
+++ b/test/testDeployCli.js
@@ -313,7 +313,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
       .onFail(() => {
         done();
       })
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
         '--static-content', 'foobar',

--- a/test/testDeployCli.js
+++ b/test/testDeployCli.js
@@ -296,7 +296,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
     it(`hlx deploy can set static content: ${mode}`, () => {
       new CLI()
         .withCommandExecutor('deploy', mockDeploy)
-        .run(['deploy',
+        .run(['deploy', '--no-auto',
           '--wsk-auth', 'secret-key',
           '--wsk-namespace', 'hlx',
           '--static-content', mode,

--- a/test/testDeployCli.js
+++ b/test/testDeployCli.js
@@ -53,6 +53,8 @@ describe('hlx deploy', () => {
     mockDeploy.withDryRun.returnsThis();
     mockDeploy.withContent.returnsThis();
     mockDeploy.withStaticContent.returnsThis();
+    mockDeploy.withFastlyAuth.returnsThis();
+    mockDeploy.withFastlyNamespace.returnsThis();
     mockDeploy.run.returnsThis();
 
     // disable static functions as well to avoid shelljs executions.

--- a/test/testDeployCli.js
+++ b/test/testDeployCli.js
@@ -18,6 +18,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const CLI = require('../src/cli.js');
 const DeployCommand = require('../src/deploy.cmd');
+const GitUtils = require('../src/gitutils');
 
 describe('hlx deploy', () => {
   // mocked command instance
@@ -55,9 +56,9 @@ describe('hlx deploy', () => {
 
     // disable static functions as well to avoid shelljs executions.
     stubs = [
-      sinon.stub(DeployCommand, 'isDirty').returns(false),
-      sinon.stub(DeployCommand, 'getRepository').returns('git-github-com-example-project-helix'),
-      sinon.stub(DeployCommand, 'getBranchFlag').returns('master'),
+      sinon.stub(GitUtils, 'isDirty').returns(false),
+      sinon.stub(GitUtils, 'getRepository').returns('git-github-com-example-project-helix'),
+      sinon.stub(GitUtils, 'getBranchFlag').returns('master'),
     ];
   });
 

--- a/test/testDeployCli.js
+++ b/test/testDeployCli.js
@@ -105,7 +105,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
       .onFail((err) => {
-        assert.equal(err, 'Error: auto-deployment requires --circleci-auth');
+        assert.equal(err, 'Error: Auto-deployment requires: --circleci-auth, --fastly-auth, --fastly-namespace');
         done();
       })
       .run(['deploy',

--- a/test/testDeployCli.js
+++ b/test/testDeployCli.js
@@ -39,6 +39,7 @@ describe('hlx deploy', () => {
 
     mockDeploy = sinon.createStubInstance(DeployCommand);
     mockDeploy.withEnableAuto.returnsThis();
+    mockDeploy.withCircleciAuth.returnsThis();
     mockDeploy.withWskHost.returnsThis();
     mockDeploy.withWskAuth.returnsThis();
     mockDeploy.withWskNamespace.returnsThis();
@@ -100,15 +101,30 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
     assert.fail('deploy w/o arguments should fail.');
   });
 
+  it('hlx deploy requires circleci auth', (done) => {
+    new CLI()
+      .withCommandExecutor('deploy', mockDeploy)
+      .onFail((err) => {
+        assert.equal(err, 'Error: auto-deployment requires --circleci-auth');
+        done();
+      })
+      .run(['deploy',
+        '--wsk-auth', 'secret-key',
+        '--wsk-namespace', 'hlx']);
+
+    assert.fail('deploy w/o arguments should fail.');
+  });
+
   it('hlx deploy works with minimal arguments', () => {
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
       ]);
 
-    sinon.assert.calledWith(mockDeploy.withEnableAuto, true);
+
+    sinon.assert.calledWith(mockDeploy.withEnableAuto, false);
     sinon.assert.calledWith(mockDeploy.withEnableDirty, false);
     sinon.assert.calledWith(mockDeploy.withWskHost, 'runtime.adobe.io');
     sinon.assert.calledWith(mockDeploy.withWskAuth, 'secret-key');
@@ -127,11 +143,11 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
     process.env.HLX_WSK_AUTH = 'sekret-key';
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-namespace', 'hlx',
       ]);
 
-    sinon.assert.calledWith(mockDeploy.withEnableAuto, true);
+    sinon.assert.calledWith(mockDeploy.withEnableAuto, false);
     sinon.assert.calledWith(mockDeploy.withEnableDirty, false);
     sinon.assert.calledWith(mockDeploy.withWskHost, 'runtime.adobe.io');
     sinon.assert.calledWith(mockDeploy.withWskAuth, 'sekret-key');
@@ -149,7 +165,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
     process.env.HLX_FOOBAR = '1234';
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
       ]);
@@ -171,7 +187,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
   it('hlx deploy works can enable dirty', () => {
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
         '--dirty',
@@ -184,7 +200,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
   it('hlx deploy can set api host', () => {
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
         '--wsk-host', 'stage.runtime.adobe.io',
@@ -197,7 +213,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
   it('hlx deploy can set log host and key', () => {
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
         '--loggly-host', 'example.logly.com',
@@ -212,7 +228,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
   it('hlx deploy can set set target', () => {
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
         '--target', 'tmp/build',
@@ -225,7 +241,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
   it('hlx deploy can set set target with -o', () => {
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
         '-o', 'tmp/build',
@@ -238,7 +254,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
   it('hlx deploy can set set docker', () => {
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
         '--docker', 'example/node8:latest',
@@ -251,7 +267,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
   it('hlx deploy can set prefix', () => {
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
         '--prefix', '_hlx_',
@@ -264,7 +280,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
   it('hlx deploy can set default', () => {
     new CLI()
       .withCommandExecutor('deploy', mockDeploy)
-      .run(['deploy',
+      .run(['deploy', '--no-auto',
         '--wsk-auth', 'secret-key',
         '--wsk-namespace', 'hlx',
         '--default', 'FEATURE', 'red, green',

--- a/test/testDeployCmd.js
+++ b/test/testDeployCmd.js
@@ -39,7 +39,7 @@ describe('hlx deploy (Integration)', () => {
   let distDir;
   let staticFile;
   let testRoot;
-  let headers;
+  let replayheaders;
   let cwd;
 
   beforeEach(async () => {
@@ -58,14 +58,14 @@ describe('hlx deploy (Integration)', () => {
 
     Replay.mode = 'replay';
     // don't record the authorization header
-    headers = Replay.headers;
+    replayheaders = Replay.headers;
     Replay.headers = Replay.headers.filter(e => e !== /^authorization/);
   });
 
   afterEach(() => {
     fs.remove(testRoot);
     Replay.mode = 'bloody';
-    Replay.headers = headers;
+    Replay.headers = replayheaders;
     $.cd(cwd);
   });
 

--- a/test/testDeployCmd.js
+++ b/test/testDeployCmd.js
@@ -39,6 +39,8 @@ describe('hlx deploy (Integration)', () => {
   let distDir;
   let staticFile;
   let testRoot;
+  let headers;
+  let cwd;
 
   beforeEach(async () => {
     testRoot = await createTestRoot();
@@ -52,14 +54,19 @@ describe('hlx deploy (Integration)', () => {
     await fs.outputFile(srcFile, 'main(){};');
     await fs.outputFile(staticFile, 'body { background-color: black; }');
 
+    cwd = process.cwd();
+
     Replay.mode = 'replay';
     // don't record the authorization header
+    headers = Replay.headers;
     Replay.headers = Replay.headers.filter(e => e !== /^authorization/);
   });
 
   afterEach(() => {
     fs.remove(testRoot);
     Replay.mode = 'bloody';
+    Replay.headers = headers;
+    $.cd(cwd);
   });
 
   it('Auto-Deploy works', (done) => {

--- a/test/testDeployCmd.js
+++ b/test/testDeployCmd.js
@@ -28,7 +28,7 @@ const strainconfig = require('../src/strain-config-utils');
 const CI_TOKEN = 'nope';
 
 Replay.mode = 'bloody';
-Replay.fixtures = __dirname + '/fixtures/';
+Replay.fixtures = `${__dirname}/fixtures/`;
 
 describe('hlx deploy (Integration)', () => {
   let hlxDir;
@@ -54,21 +54,21 @@ describe('hlx deploy (Integration)', () => {
 
     Replay.mode = 'replay';
     // don't record the authorization header
-    Replay.headers = Replay.headers.filter(e => e == /^authorization/);
+    Replay.headers = Replay.headers.filter(e => e !== /^authorization/);
   });
 
   afterEach(() => {
     fs.remove(testRoot);
     Replay.mode = 'bloody';
-  })
+  });
 
-  it('Auto-Deploy works', done => {
+  it('Auto-Deploy works', (done) => {
     try {
       $.cd(testRoot);
       $.exec('git clone https://github.com/trieloff/helix-helpx.git');
       $.cd(path.resolve(testRoot, 'helix-helpx'));
 
-      const result = new DeployCommand()
+      new DeployCommand()
         .withWskHost('runtime.adobe.io')
         .withWskAuth('secret-key')
         .withWskNamespace('hlx')
@@ -79,7 +79,8 @@ describe('hlx deploy (Integration)', () => {
         .withTarget(buildDir)
         .withStrainFile(strainsFile)
         .withCircleciAuth(CI_TOKEN)
-        .run().then(() => {console.log('done');done();});
+        .run()
+        .then(() => { done(); });
     } catch (e) {
       done(e);
     }

--- a/test/testDeployCmd.js
+++ b/test/testDeployCmd.js
@@ -59,7 +59,7 @@ describe('hlx deploy (Integration)', () => {
     Replay.mode = 'replay';
     // don't record the authorization header
     replayheaders = Replay.headers;
-    Replay.headers = Replay.headers.filter(e => e !== /^authorization/);
+    Replay.headers = Replay.headers.filter(e => new RegExp(e).toString() !== new RegExp(/^authorization/).toString());
   });
 
   afterEach(() => {
@@ -85,6 +85,8 @@ describe('hlx deploy (Integration)', () => {
         .withContent('git@github.com:adobe/helix-cli')
         .withTarget(buildDir)
         .withStrainFile(strainsFile)
+        .withFastlyAuth('nope')
+        .withFastlyNamespace('justtesting')
         .withCircleciAuth(CI_TOKEN)
         .run()
         .then(() => { done(); });

--- a/test/testDeployCmd.js
+++ b/test/testDeployCmd.js
@@ -140,4 +140,11 @@ describe('hlx deploy (Integration)', () => {
     // todo: this will probably fail on a fork
     assert.equal(strains[0].githubStatic.owner, 'adobe');
   });
+  
+  it('setDeployOptions() #unittest', () => {
+    const options = DeployCommand.getBuildVarOptions('FOO', 'BAR', 'adobe', 'helix-cli', {});
+    assert.equal(options.method, 'POST');
+    assert.equal(JSON.parse(options.body).name, 'FOO');
+    assert.equal(JSON.parse(options.body).value, 'BAR');
+  });
 });

--- a/test/testDeployCmd.js
+++ b/test/testDeployCmd.js
@@ -16,8 +16,8 @@ const Replay = require('replay');
 const fs = require('fs-extra');
 const assert = require('assert');
 const path = require('path');
-const { createTestRoot, assertZipEntry, assertFile } = require('./utils.js');
 const $ = require('shelljs');
+const { createTestRoot, assertZipEntry, assertFile } = require('./utils.js');
 const DeployCommand = require('../src/deploy.cmd.js');
 const strainconfig = require('../src/strain-config-utils');
 
@@ -147,7 +147,7 @@ describe('hlx deploy (Integration)', () => {
     const thirdrun = fs.readFileSync(strainsFile).toString();
     assert.notEqual(firstrun, thirdrun);
   }).timeout(10000);
-});
+
 
   it('includes the static files into the zip for static-content=bundled', async () => {
     await new DeployCommand()
@@ -191,7 +191,8 @@ describe('hlx deploy (Integration)', () => {
     // todo: this will probably fail on a fork
     assert.equal(strains[0].githubStatic.owner, 'adobe');
   });
-  
+});
+
 describe('DeployCommand #unittest', () => {
   it('setDeployOptions() #unittest', () => {
     const options = DeployCommand.getBuildVarOptions('FOO', 'BAR', 'adobe', 'helix-cli', {});

--- a/test/testDeployCmd.js
+++ b/test/testDeployCmd.js
@@ -16,12 +16,8 @@ const Replay = require('replay');
 const fs = require('fs-extra');
 const assert = require('assert');
 const path = require('path');
-<<<<<<< HEAD
 const { createTestRoot, assertZipEntry, assertFile } = require('./utils.js');
-=======
 const $ = require('shelljs');
-const { createTestRoot, assertFile } = require('./utils.js');
->>>>>>> 6ba8f85... added integration test (with fixtures) for auto-deploy
 const DeployCommand = require('../src/deploy.cmd.js');
 const strainconfig = require('../src/strain-config-utils');
 

--- a/test/testDeployCmd.js
+++ b/test/testDeployCmd.js
@@ -12,12 +12,23 @@
 
 /* eslint-env mocha */
 
+const Replay = require('replay');
 const fs = require('fs-extra');
 const assert = require('assert');
 const path = require('path');
+<<<<<<< HEAD
 const { createTestRoot, assertZipEntry, assertFile } = require('./utils.js');
+=======
+const $ = require('shelljs');
+const { createTestRoot, assertFile } = require('./utils.js');
+>>>>>>> 6ba8f85... added integration test (with fixtures) for auto-deploy
 const DeployCommand = require('../src/deploy.cmd.js');
 const strainconfig = require('../src/strain-config-utils');
+
+const CI_TOKEN = 'nope';
+
+Replay.mode = 'bloody';
+Replay.fixtures = __dirname + '/fixtures/';
 
 describe('hlx deploy (Integration)', () => {
   let hlxDir;
@@ -27,9 +38,10 @@ describe('hlx deploy (Integration)', () => {
   let zipFile;
   let distDir;
   let staticFile;
+  let testRoot;
 
   beforeEach(async () => {
-    const testRoot = await createTestRoot();
+    testRoot = await createTestRoot();
     hlxDir = path.resolve(testRoot, '.hlx');
     buildDir = path.resolve(hlxDir, 'build');
     distDir = path.resolve(hlxDir, 'dist');
@@ -39,7 +51,39 @@ describe('hlx deploy (Integration)', () => {
     zipFile = path.resolve(buildDir, 'my-prefix-html.zip');
     await fs.outputFile(srcFile, 'main(){};');
     await fs.outputFile(staticFile, 'body { background-color: black; }');
+
+    Replay.mode = 'replay';
+    // don't record the authorization header
+    Replay.headers = Replay.headers.filter(e => e == /^authorization/);
   });
+
+  afterEach(() => {
+    fs.remove(testRoot);
+    Replay.mode = 'bloody';
+  })
+
+  it('Auto-Deploy works', done => {
+    try {
+      $.cd(testRoot);
+      $.exec('git clone https://github.com/trieloff/helix-helpx.git');
+      $.cd(path.resolve(testRoot, 'helix-helpx'));
+
+      const result = new DeployCommand()
+        .withWskHost('runtime.adobe.io')
+        .withWskAuth('secret-key')
+        .withWskNamespace('hlx')
+        .withEnableAuto(true)
+        .withEnableDirty(true)
+        .withDryRun(true)
+        .withContent('git@github.com:adobe/helix-cli')
+        .withTarget(buildDir)
+        .withStrainFile(strainsFile)
+        .withCircleciAuth(CI_TOKEN)
+        .run().then(() => {console.log('done');done();});
+    } catch (e) {
+      done(e);
+    }
+  }).timeout(15000);
 
   it('Dry-Running works', async () => {
     await new DeployCommand()
@@ -97,6 +141,7 @@ describe('hlx deploy (Integration)', () => {
     const thirdrun = fs.readFileSync(strainsFile).toString();
     assert.notEqual(firstrun, thirdrun);
   }).timeout(10000);
+});
 
   it('includes the static files into the zip for static-content=bundled', async () => {
     await new DeployCommand()
@@ -141,6 +186,7 @@ describe('hlx deploy (Integration)', () => {
     assert.equal(strains[0].githubStatic.owner, 'adobe');
   });
   
+describe('DeployCommand #unittest', () => {
   it('setDeployOptions() #unittest', () => {
     const options = DeployCommand.getBuildVarOptions('FOO', 'BAR', 'adobe', 'helix-cli', {});
     assert.equal(options.method, 'POST');

--- a/test/testGitUtils.js
+++ b/test/testGitUtils.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+const assert = require('assert');
+const GitUtils = require('../src/gitutils');
+
+describe('Testing GitUtils', () => {
+  it('getOrigin #unit', () => {
+    assert.ok(GitUtils.getOrigin());
+    assert.ok(/helix-cli/.test(GitUtils.getOrigin()));
+  });
+
+  it('getOriginURL #unit', () => {
+    assert.ok(GitUtils.getOriginURL());
+    assert.equal(GitUtils.getOriginURL().repo, 'helix-cli');
+  });
+});

--- a/test/testUpCmd.js
+++ b/test/testUpCmd.js
@@ -31,7 +31,8 @@ describe('Integration test for up command', () => {
   let buildDir;
   let welcomeTxtName;
 
-  beforeEach(async () => {
+  beforeEach(async function before() {
+    this.timeout(20000);
     const testRoot = await createTestRoot();
     testDir = path.resolve(testRoot, 'project');
     buildDir = path.resolve(testRoot, '.hlx/build');


### PR DESCRIPTION
This is a fix for #135 and obsoletes #130. It does no longer have a dependency on #112, as this might take a bit longer to be discussed.

----

The default for `hlx deploy` is `hlx deploy --auto`, which will set up a CI/CD pipeline for the given repository. To do this, we depend on:

- [x] #123 

(this branch is based on both branches to avoid later merge conflicts)

The rough process will look like this:

- [x] `hlx deploy` gets a `--circleci-auth` options
- [x] `curl -X "POST" "https://circleci.com/api/v1.1/project/github/trieloff/helix-helpx/follow"`
- [x] `curl -X "POST" "https://circleci.com/api/v1.1/project/github/trieloff/helix-helpx/envvar" -H 'Accept: application/json' -H 'Content-Type: application/json' -d $'{"name": "HLX_WSK_AUTH","value": "FOO"}'` (repeat for all arguments that are relevant to `hlx deploy` and `hlx strain`)
- [x] trigger a new build if CI has already been set up
- [x] tune the default `.circleci/config.yaml`