### PR TITLE
Edge side implementation of Param whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,31 @@ $ hlx strain --fastly-auth <key> --fastly-namespace <serviceid>
 💀  Purged entire cache
 ```
 
+### Passing Request Parameters
+
+Every request parameter is a potential cache-buster and given that modern web application practices liberally append request parameters for tracking purposes or to manage state for client-side applications, **Helix filters out all request parameters by default**.
+
+This means, the client side of your application will still be able to access request parameters, but your server(less)-side scripts and templates will not see any parameters.
+
+If you need to pass request parameters, you can whitelist the parameters you need using the `strain.params` configuration. The value of `params` is an array of whitelisted parameter names.
+
+```yaml
+- strain:
+    name: default
+    code: /hlx/default/git-github-com-adobe-helix-cli-git--dirty--
+    params:
+      - foo
+      - bar
+    content:
+      repo: helix-cli
+      ref: master
+      owner: adobe
+```
+
+In the example above, the parameters `foo` and `bar` have been enabled. A request made to `https://www.example.com/index.html?foo=here&bar=there&baz=everywhere` will enable your application to read the `foo` and `bar` parameters. The `baz` parameter and all other parameters will be filtered out.
+
+Every allowed parameter value will affect the caching of your site in the CDN.
+
 ### Directory Index
 
 The default behavior for directory indexes is to load `index.html` when requesting a path ending with `/`,

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -48,6 +48,23 @@ sub hlx_index {
   }
 }
 
+# Gets the white-listed params for the current strain
+sub hlx_params {
+  set req.http.X-Params = "";
+  set req.http.X-Encoded-Params = "";
+
+  # first load the params from the strain
+  set req.http.X-Params = table.lookup(strain_params, req.http.X-Strain);
+  if (!req.http.X-Params) {
+    set req.http.X-Params = table.lookup(strain_params, "default");
+  }
+  if (req.http.X-Params) {
+    set req.http.X-Old-Url = req.url;
+    set req.url = querystring.regfilter(req.url, req.http.X-Params);
+    set req.http.X-Encoded-Params = urlencode(req.url.qs);
+  }
+}
+
 # Gets the content repo
 sub hlx_repo {
   set req.http.X-Repo = table.lookup(strain_repos, req.http.X-Strain);
@@ -335,8 +352,9 @@ sub vcl_recv {
       }
       set req.url = "/" + var.owner + "/" + var.repo + "/" + var.ref + "/" + var.dir + "/" + req.url.basename + "?" + req.url.qs;
     } else {
+      call hlx_params;
       # Invoke OpenWhisk
-      set req.url = "/api/v1/web" + var.action + "?owner=" + var.owner + "&repo=" + var.repo + "&ref=" + var.ref + "&path=" + var.dir + "/" + var.name + ".md" + "&selector=" + var.selector + "&extension=" + req.url.ext + "&branch=" + var.branch + "&strain=" + var.strain + "&GITHUB_KEY=" + table.lookup(secrets, "GITHUB_TOKEN");
+      set req.url = "/api/v1/web" + var.action + "?owner=" + var.owner + "&repo=" + var.repo + "&ref=" + var.ref + "&path=" + var.dir + "/" + var.name + ".md" + "&selector=" + var.selector + "&extension=" + req.url.ext + "&branch=" + var.branch + "&strain=" + var.strain + "&GITHUB_KEY=" + table.lookup(secrets, "GITHUB_TOKEN") + "&params=" + req.http.X-Encoded-Params;
     }
   }
 

--- a/src/strain.cmd.js
+++ b/src/strain.cmd.js
@@ -48,6 +48,7 @@ class StrainCommand {
 
     this._dictionaries = {
       secrets: null,
+      strain_params: null,
       strain_action_roots: null,
       strain_owners: null,
       strain_refs: null,
@@ -132,6 +133,14 @@ class StrainCommand {
   withVclFile(value) {
     this._vclFile = value;
     return this;
+  }
+
+  /**
+   * Turns a list of parameter names into a regular expression string.
+   * @param {Array(String)} params a list of parameter names
+   */
+  static makeFilter(params) {
+    return `^${params.join('|')}$`;
   }
 
   /**
@@ -577,6 +586,10 @@ class StrainCommand {
       // optional
       makeStrainjob('strain_index_files', strain.name, strain.index, '🗂  Set directory index');
       makeStrainjob('strain_root_paths', strain.name, strain.content.root, '🌲  Set content root');
+
+      if (strain.params) {
+        makeStrainjob('strain_params', strain.name, StrainCommand.makeFilters(strain.params), '🗃  Set parameter filter');
+      }
 
       // static
       if (strain.githubStatic) {


### PR DESCRIPTION
This is the edge-side implementation for #126: it adds everything on the edge and cli-side to enable passing a parameter `params` that has the names and values of all whitelisted parameters in a URL encoded string. 

On the action-side, you would need to take the value of `params.params` and use `querystring.parse` (https://nodejs.org/api/querystring.html#querystring_querystring_parse_str_sep_eq_options) to get a proper object.

I'm not a 100% sure where you would put that, @kptdobe @tripodsan – therefore only a partial solution to #126 