### PR TITLE
Support for Large Static Binaries

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -488,7 +488,13 @@ sub vcl_fetch {
     esi;
   }
 
-  if (beresp.status == 404 || beresp.status == 204) {
+  if (beresp.http.X-Static == "Raw/Static") {
+    if (beresp.status == 307) {
+      //restart
+    } else {
+      return(deliver);
+    }
+  } elseif (beresp.status == 404 || beresp.status == 204) {
     # That was a miss. Let's try to restart.
     set beresp.http.X-Status = beresp.status + "-Restart " + req.restarts;
     set beresp.status = 404;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -395,7 +395,8 @@ sub vcl_recv {
   }
 
   # enable IO for image file-types
-  if (req.url.ext ~ "(?i)(?:gif|png|jpe?g|webp)")  {
+  # but not for static images or redirected images
+  if (req.url.ext ~ "(?i)(?:gif|png|jpe?g|webp)" && (req.http.X-Static != "Static") && (req.http.X-Static == "Redirect"))  {
     set req.http.X-Fastly-Imageopto-Api = "fastly";
   }
 

--- a/src/openwhisk/static.js
+++ b/src/openwhisk/static.js
@@ -15,14 +15,15 @@ const crypto = require('crypto');
 const mime = require('mime-types');
 /* eslint-disable no-console */
 
-function error(message) {
-  console.error(message);
+function error(message, code = 500) {
+  console.error('delivering error', message, code);
   return {
-    statusCode: 500,
+    statusCode: code,
     headers: {
       'Content-Type': 'text/html',
+      'X-Static': 'Raw/Static',
     },
-    body: `Error 500: Internal Server Error\n${message}`,
+    body: `Error ${code}: ${message}`,
   };
 }
 
@@ -91,8 +92,9 @@ function staticBase(owner, repo, entry, ref, strain = 'default') {
 function deliverPlain(owner, repo, ref, entry, root) {
   const cleanentry = (`${root}/${entry}`).replace(/^\//, '').replace(/[/]+/g, '/');
   console.log('deliverPlain()', owner, repo, ref, cleanentry);
+  const url = `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${cleanentry}`;
   const rawopts = {
-    url: `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${cleanentry}`,
+    url,
     headers: {
       'User-Agent': 'Project Helix Static',
     },
@@ -102,16 +104,35 @@ function deliverPlain(owner, repo, ref, entry, root) {
 
   return request.get(rawopts).then((response) => {
     const type = mime.lookup(cleanentry) || 'application/octet-stream';
-    const body = getBody(type, response.body);
-    console.log(`delivering file ${cleanentry} type ${type} binary: ${isBinary(type)}`);
+    const size = parseInt(response.headers['content-length'], 10);
+    console.log('size', size);
+    if (size < 3000) {
+      const body = getBody(type, response.body);
+      console.log(`delivering file ${cleanentry} type ${type} binary: ${isBinary(type)}`);
+      return {
+        headers: addHeaders({
+          'Content-Type': type,
+          'X-Static': 'Raw/Static',
+        }, ref, response.body),
+        body,
+      };
+    }
+    console.log('Redirecting to GitHub');
     return {
-      headers: addHeaders({
-        'Content-Type': type,
+      statusCode: 307,
+      headers: {
+        Location: url,
+        'X-Content-Type': type,
         'X-Static': 'Raw/Static',
-      }, ref, response.body),
-      body,
+      },
     };
-  }).catch(error);
+  }).catch((rqerror) => {
+    console.error('REQUEST FAILED', rqerror.response.body.toString());
+    if (rqerror.statusCode === 404) {
+      return error(rqerror.response.body.toString(), 404);
+    }
+    return error(rqerror.message, rqerror.statusCode);
+  });
 }
 
 /**
@@ -177,7 +198,7 @@ async function main({
     return deliverPlain(owner, repo, ref, entry, root);
   }
 
-  return forbidden;
+  return forbidden();
 }
 
 module.exports = {

--- a/src/openwhisk/static.js
+++ b/src/openwhisk/static.js
@@ -15,6 +15,9 @@ const crypto = require('crypto');
 const mime = require('mime-types');
 /* eslint-disable no-console */
 
+// one megabyte openwhisk limit + 20% Base64 inflation + safety padding
+const REDIRECT_LIMIT = 750000;
+
 function error(message, code = 500) {
   console.error('delivering error', message, code);
   return {
@@ -106,7 +109,7 @@ function deliverPlain(owner, repo, ref, entry, root) {
     const type = mime.lookup(cleanentry) || 'application/octet-stream';
     const size = parseInt(response.headers['content-length'], 10);
     console.log('size', size);
-    if (size < 3000) {
+    if (size < REDIRECT_LIMIT) {
       const body = getBody(type, response.body);
       console.log(`delivering file ${cleanentry} type ${type} binary: ${isBinary(type)}`);
       return {

--- a/test/testStatic.js
+++ b/test/testStatic.js
@@ -17,7 +17,8 @@ describe('Static Delivery Action #unittest', () => {
   it('error() #unittest', () => {
     const error = index.error('Test');
     assert.equal(error.statusCode, '500');
-    assert.ok(error.body.match('Internal Server Error'));
+    assert.ok(error.body.match('500'));
+    assert.ok(!error.body.match('404'));
   });
 
   it('addHeaders() #unittest', () => {


### PR DESCRIPTION
This is a workaround for the 1 MB response size limit in OpenWhisk:

- if `static.js` detects a file that is bigger than 750k, it will send a `307` redirect to the `raw.githubusercontent.com` location, and set the correct (inferred) `X-Content-Type` header
- when `vcl_fetch` gets a `307` status code from `static.js`, it will restart the request with the URL set in the `Location` header
- when that response is received in `vcl_fetch` again, the `Content-Type` header of the 2nd response will be overwritten with the `X-Content-Type` header from the 1st response 