### PR TITLE
Code lookup in the wrong repo with 0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,9 +104,9 @@
       }
     },
     "@adobe/petridish": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@adobe/petridish/-/petridish-1.3.0.tgz",
-      "integrity": "sha512-IbI0sP/t52lvSGwJvWkOLzIqkNV0PBqmNZh1JDFNoPJlaYzBz4drJJWFWJi5b6dvSs+X20s4rsMqnlPlMjd84Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@adobe/petridish/-/petridish-1.4.0.tgz",
+      "integrity": "sha512-+wIy0PicQY7Y/DtiLfhCzcT6ZSqZbmwE82OjIqWRfALRtMma1L1vJBjjmSCR6gtill0HVq45bknwggDePM771w==",
       "requires": {
         "@adobe/git-server": "^0.9.0",
         "@adobe/htlengine": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@adobe/hypermedia-pipeline": "^0.5.0",
     "@adobe/openwhisk-loggly-wrapper": "^0.3.0",
     "@adobe/parcel-plugin-htl": "0.8.0",
-    "@adobe/petridish": "^1.3.0",
+    "@adobe/petridish": "^1.4.0",
     "archiver": "^3.0.0",
     "calibre": "^1.1.1",
     "chalk": "^2.4.1",

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -77,7 +77,7 @@ class UpCommand extends BuildCommand {
     this._project = new HelixProject()
       .withCwd(this._cwd)
       .withBuildDir(this._target)
-      .withDistDir(this._distDir)
+      .withWebRootDir(this._webroot)
       .withDisplayVersion(pkgJson.version);
 
     if (this._httpPort >= 0) {

--- a/test/testUpCmd.js
+++ b/test/testUpCmd.js
@@ -97,7 +97,7 @@ describe('Integration test for up command', () => {
             { pattern: 'welcome.txt', with: welcomeTxtName },
           ];
           await assertHttp(`http://localhost:${cmd.project.server.port}/index.html`, 200, 'simple_response.html', replacements);
-          await assertHttp(`http://localhost:${cmd.project.server.port}/${welcomeTxtName}`, 200, 'welcome_response.txt');
+          await assertHttp(`http://localhost:${cmd.project.server.port}/dist/${welcomeTxtName}`, 200, 'welcome_response.txt');
           myDone();
         } catch (e) {
           myDone(e);


### PR DESCRIPTION
- use latest petridish v1.4.0
- Code lookup in the wrong repo with 0.7.5 (Fixes #197)
