### PR TITLE
Setting a "content root" leads to invalid content delivery #188

### DIFF
--- a/src/publish.cmd.js
+++ b/src/publish.cmd.js
@@ -407,9 +407,9 @@ class PublishCommand {
       if (uri.path && uri.path !== '/') {
         const pathname = uri.path.replace(/\/$/, '');
         return Object.assign({
-          condition: `req.http.Host == "${uri.host}" && req.url.dirname ~ "^${uri.path}"`,
+          condition: `req.http.Host == "${uri.host}" && (req.url.dirname ~ "^${pathname}$" || req.url.dirname ~ "^${pathname}/")`,
           vcl: `
-  set req.http.X-Dirname = regsub(req.url.dirname, "^${pathname}", "/");`,
+  set req.http.X-Dirname = regsub(req.url.dirname, "^${pathname}", "");`,
         }, strain);
       }
       return Object.assign({

--- a/test/fixtures/urls.vcl
+++ b/test/fixtures/urls.vcl
@@ -3,9 +3,9 @@ if (req.http.Host == "www.primordialsoup.life") {
   set req.http.X-Strain = "default";
 } else if (req.http.Host == "debug.primordialsoup.life") {
   set req.http.X-Strain = "debug";
-} else if (req.http.Host == "debug.primordialsoup.life" && req.url.dirname ~ "^/foo/bar") {
+} else if (req.http.Host == "debug.primordialsoup.life" && (req.url.dirname ~ "^/foo/bar$" || req.url.dirname ~ "^/foo/bar/")) {
   set req.http.X-Strain = "path";
-  set req.http.X-Dirname = regsub(req.url.dirname, "^/foo/bar", "/");
+  set req.http.X-Dirname = regsub(req.url.dirname, "^/foo/bar", "");
 } else {
   set req.http.X-Strain = "default";
 }

--- a/test/testPublishCmd.js
+++ b/test/testPublishCmd.js
@@ -56,14 +56,14 @@ describe('hlx strain (VCL) generation', () => {
     const strainfile = strainconfig.load(fs.readFileSync(path.resolve(__dirname, 'fixtures/simple-condition.yaml')));
     const vclfile = fs.readFileSync(path.resolve(__dirname, 'fixtures/simple-condition.vcl')).toString();
     // console.log(StrainCommand.getVCL(strainfile));
-    assert.equal(vclfile, StrainCommand.getVCL(strainfile));
+    assert.equal(vclfile.trim(), StrainCommand.getVCL(strainfile).trim());
   });
 
   it('getVCL generates VLC for URL-based conditions', () => {
     const strainfile = strainconfig.load(fs.readFileSync(path.resolve(__dirname, 'fixtures/urls.yaml')));
     const vclfile = fs.readFileSync(path.resolve(__dirname, 'fixtures/urls.vcl')).toString();
     // console.log(StrainCommand.getVCL(strainfile));
-    assert.equal(vclfile, StrainCommand.getVCL(strainfile));
+    assert.equal(vclfile.trim(), StrainCommand.getVCL(strainfile).trim());
   });
 });
 


### PR DESCRIPTION
see #188

the original test was too weak, as it:
- didn't consider partial matches, i.e. `/helpix/foo/` matches `^/help` which would result in `/somerootix/foo/`
- didn't handle roots with trailing slashes, i.e. `/help` would not match `^/help/`