### PR TITLE
Fixes Reduced CHR when applying default image TTLs

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -484,6 +484,7 @@ sub vcl_fetch {
       # apply a longer ttl for images
       if (req.url.ext ~ "(?i)(?:gif|png|jpe?g|webp)") {
         set beresp.ttl = 2592000s;
+        set beresp.http.Cache-Control = "max-age=2592000, public";
       }
 
     } else {


### PR DESCRIPTION
Recently uncovered an issue with the Fastly IO Boilerplate which can
result in reduced CHR when the origin doesn’t pass up caching headers
and we fallback to default TTLs.
Issue would exhibit itself by decreased TTL at the edge resulting in
increased miss-rate to the shield.

Resolves issue: https://github.com/adobe/helix-cli/issues/253