### PR TITLE
Default CI config cannot be executed ootb #283

### DIFF
--- a/demos/full/.circleci/config.yml
+++ b/demos/full/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
 
         - run:
             name: Installing Helix CLI
-            command: npm install @adobe/helix-cli
+            command: npm install @adobe/helix-cli --save=false
 
         - save_cache:
             paths:

--- a/demos/simple/.circleci/config.yml
+++ b/demos/simple/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
 
         - run:
             name: Installing Helix CLI
-            command: npm install @adobe/helix-cli
+            command: npm install @adobe/helix-cli --save=false
 
         - save_cache:
             paths:
@@ -28,8 +28,6 @@ jobs:
         - run:
             name: Building Templates
             command: npx hlx build
-
-        - run: git diff
 
         - run:
             name: Deploying to Adobe I/O Runtime

--- a/src/perf.js
+++ b/src/perf.js
@@ -27,6 +27,8 @@ module.exports = function perf() {
     desc: 'Test performance',
     builder: (yargs) => {
       yargs
+        .env('HLX')
+        .strict(false)
         .option('calibre-auth', {
           describe: 'API token from https://calibreapp.com/',
           type: 'string',

--- a/test/testPerfCli.js
+++ b/test/testPerfCli.js
@@ -62,6 +62,17 @@ describe('hlx perf (CLI)', () => {
       .run(['perf']);
   });
 
+  it.only('hlx perf accepts HLX_CALIBRE_AUTH', () => {
+    process.env.HLX_CALIBRE_AUTH = 'nope-nope-nope';
+    new CLI()
+      .withCommandExecutor('perf', mockPerf)
+      .onFail((err) => {
+        assert.fail(err);
+      })
+      .run(['perf']);
+    assert.ok(true);
+  });
+
   it('hlx perf works with minimal arguments', () => {
     new CLI()
       .withCommandExecutor('perf', mockPerf)

--- a/test/testPerfCli.js
+++ b/test/testPerfCli.js
@@ -62,7 +62,7 @@ describe('hlx perf (CLI)', () => {
       .run(['perf']);
   });
 
-  it.only('hlx perf accepts HLX_CALIBRE_AUTH', () => {
+  it('hlx perf accepts HLX_CALIBRE_AUTH', () => {
     process.env.HLX_CALIBRE_AUTH = 'nope-nope-nope';
     new CLI()
       .withCommandExecutor('perf', mockPerf)


### PR DESCRIPTION
PR for #283 

- [x] `git diff` times out
- [x] `hlx deploy` fails because of local modifications
- [x] `hlx perf` fails because of missing `calibre-auth`
