### PR TITLE
Better progress bars

### DIFF
--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -176,11 +176,12 @@ class DeployCommand extends AbstractCommand {
 
     const ticks = {};
     const tick = (message, name) => {
+      const shortname = name.replace(/\/package.json.*/, '').replace(/node_modules\//, '');
       bar.tick({
-        action: name ? `packaging ${name}` : '',
+        action: name ? `packaging ${shortname}` : '',
       });
       if (message) {
-        this.log.log({
+        this.log.maybe({
           progress: true,
           level: 'info',
           message,

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -189,6 +189,11 @@ class DeployCommand extends AbstractCommand {
       }
     };
 
+    if (this._dryRun) {
+      log.debug('Skipping ZIP file creation for ' + info.name);
+      return Promise.resolve({});
+    }
+
     return new Promise((resolve, reject) => {
       const archiveName = `${info.name}.zip`;
       const zipFile = path.resolve(this._target, archiveName);
@@ -466,7 +471,9 @@ class DeployCommand extends AbstractCommand {
     await Promise.all(scripts.map(script => this.createPackage(script, bar)));
 
     // read files ...
-    const read = scripts.map(script => fs.readFile(script.zipFile)
+    const read = scripts
+      .filter(script => script.zipFile) //skip empty zip files
+      .map(script => fs.readFile(script.zipFile)
       .then(action => ({ script, action })));
 
     // ... and deploy

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -49,7 +49,6 @@ class DeployCommand extends AbstractCommand {
   }
 
   static getDefaultContentURL() {
-    
     if (fs.existsSync('helix-config.yaml')) {
       const conf = yaml.safeLoad(fs.readFileSync('helix-config.yaml'));
       if (conf && conf.contentRepo) {

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -49,6 +49,7 @@ class DeployCommand extends AbstractCommand {
   }
 
   static getDefaultContentURL() {
+    
     if (fs.existsSync('helix-config.yaml')) {
       const conf = yaml.safeLoad(fs.readFileSync('helix-config.yaml'));
       if (conf && conf.contentRepo) {
@@ -188,11 +189,6 @@ class DeployCommand extends AbstractCommand {
         });
       }
     };
-
-    if (this._dryRun) {
-      log.debug(`Skipping ZIP file creation for ${info.name}`);
-      return Promise.resolve({});
-    }
 
     return new Promise((resolve, reject) => {
       const archiveName = `${info.name}.zip`;

--- a/src/deploy.cmd.js
+++ b/src/deploy.cmd.js
@@ -190,7 +190,7 @@ class DeployCommand extends AbstractCommand {
     };
 
     if (this._dryRun) {
-      log.debug('Skipping ZIP file creation for ' + info.name);
+      log.debug(`Skipping ZIP file creation for ${info.name}`);
       return Promise.resolve({});
     }
 
@@ -472,9 +472,9 @@ class DeployCommand extends AbstractCommand {
 
     // read files ...
     const read = scripts
-      .filter(script => script.zipFile) //skip empty zip files
+      .filter(script => script.zipFile) // skip empty zip files
       .map(script => fs.readFile(script.zipFile)
-      .then(action => ({ script, action })));
+        .then(action => ({ script, action })));
 
     // ... and deploy
     bar.total += scripts.length * 2;


### PR DESCRIPTION
Partial fix for #341: no more line breaks in the deploy progress bar, but we should still try to have only one progress bar per action