### PR TITLE
Enable bash completion

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -84,7 +84,7 @@ class CLI {
 
     return logArgs(argv)
       .fail(this._failFn)
-      .exitProcess(args.indexOf('--get-yargs-completions')>-1)
+      .exitProcess(args.indexOf('--get-yargs-completions') > -1)
       .strict()
       .demandCommand(1, MIN_MSG)
       .epilogue('for more information, find our manual at https://github.com/adobe/helix-cli')

--- a/src/cli.js
+++ b/src/cli.js
@@ -84,11 +84,12 @@ class CLI {
 
     return logArgs(argv)
       .fail(this._failFn)
-      .exitProcess(false)
+      .exitProcess(args.indexOf('--get-yargs-completions')>-1)
       .strict()
       .demandCommand(1, MIN_MSG)
       .epilogue('for more information, find our manual at https://github.com/adobe/helix-cli')
       .help()
+      .completion()
       .parse(args);
   }
 }


### PR DESCRIPTION
This PR enables basic bash completion #202 

![bashcompletion](https://user-images.githubusercontent.com/39613/49293801-6b37ae00-f4b1-11e8-98cf-04e02b10824c.gif)

You will still need to install the completion script (assuming `hlx` is a global command, not alias)

for `~/.bash_profile`
```bash
_yargs_completions()
{
    local cur_word args type_list

    cur_word="${COMP_WORDS[COMP_CWORD]}"
    args=("${COMP_WORDS[@]}")

    # ask yargs to generate completions.
    type_list=$(hlx --get-yargs-completions "${args[@]}")

    COMPREPLY=( $(compgen -W "${type_list}" -- ${cur_word}) )

    # if no match was found, fall back to filename completion
    if [ ${#COMPREPLY[@]} -eq 0 ]; then
      COMPREPLY=( $(compgen -f -- "${cur_word}" ) )
    fi

    return 0
}
complete -F _yargs_completions hlx
```

or for `~/.zshrc`

```bash

_yargs_completions()
{
  local reply
  local si=$IFS

  # ask yargs to generate completions.
  IFS=$'\n' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" hlx --get-yargs-completions "${words[@]}"))
  IFS=$si

  _describe 'values' reply
}
compdef _yargs_completions hlx
```