### PR TITLE
🐛 fix infinite watch / build loop that only affected me

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5491,8 +5491,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5510,13 +5509,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5529,18 +5526,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5643,8 +5637,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5654,7 +5647,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5667,20 +5659,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5697,7 +5686,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5770,8 +5758,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5781,7 +5768,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5857,8 +5843,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5888,7 +5873,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5906,7 +5890,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5945,13 +5928,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9634,7 +9615,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9956,8 +9936,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -10062,7 +10041,6 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -10109,8 +10087,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -10376,8 +10353,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -68,14 +68,15 @@ class UpCommand extends BuildCommand {
     this._watcher = watch(this.directory, {
       recursive: true,
     }, (eventType, filename) => {
-      if (filename.indexOf('src/') < 0 && filename !== HELIX_CONFIG) {
+      const file = filename.split(process.cwd()).join(''); // only consider paths starting from project root
+      if (file.indexOf('src/') < 0 && file !== HELIX_CONFIG) {
         return;
       }
       // ignore some files
-      if (/(.*\.swx|.*\.swp|.*~)/.test(filename)) {
+      if (/(.*\.swx|.*\.swp|.*~)/.test(file)) {
         return;
       }
-      modifiedFiles[filename] = true;
+      modifiedFiles[file] = true;
       if (timer) {
         clearTimeout(timer);
       }

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -12,6 +12,7 @@
 
 const glob = require('glob');
 const opn = require('opn');
+const path = require('path');
 const readline = require('readline');
 const watch = require('node-watch');
 const { HelixProject } = require('@adobe/helix-simulator');
@@ -68,7 +69,8 @@ class UpCommand extends BuildCommand {
     this._watcher = watch(this.directory, {
       recursive: true,
     }, (eventType, filename) => {
-      const file = filename.split(process.cwd()).join(''); // only consider paths starting from project root
+      // only consider paths starting from project root
+      const file = path.relative(this.directory, filename);
       if (file.indexOf('src/') < 0 && file !== HELIX_CONFIG) {
         return;
       }


### PR DESCRIPTION
Turns out the problem was because I have all of my projects under `~/src/`, i.e. `~/src/Adobe-Developer-Site`, `~/src/helix-cli`, etc. So, the first conditional in this function never was true, so the short-circuit didn't work on my machine.

My approach to fix was to remove the process' current working directory from the absolute path of changed filenames passed into the watcher method.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
