### PR TITLE
add adobe-helix-* to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 .github
 .nyc_output
 .vscode
+adobe-helix-*
 logs
 test
 test-results.xml


### PR DESCRIPTION
`npm pack` would currently include previously built packages which are still lying around

Relates to #405 