### PR TITLE
Fix parcel-bundler regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "object-hash": "^1.3.0",
     "openwhisk": "3.18.0",
     "opn": "^5.3.0",
-    "parcel-bundler": "^1.10.0",
+    "parcel-bundler": "1.10.x",
     "progress": "^2.0.1",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.5",


### PR DESCRIPTION
parcel-bundler 1.11.x moved it's logger library into
it's own repo. This just makes sure we do not automatically
upgrade to that version

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
