### PR TITLE
default prefix fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ If you need to pass request parameters, you can whitelist the parameters you nee
 ```yaml
 strains:
   default:
-    code: /hlx/default/git-github-com-adobe-helix-cli-git--dirty--
+    code: /hlx/default/github-com-adobe-helix-cli--master-dirty--
     params:
       - foo
       - bar
@@ -164,7 +164,7 @@ by adding an `index` property:
 ```yaml
 strains:
   default:
-    code: /hlx/default/git-github-com-adobe-helix-cli-git--dirty--
+    code: /hlx/default/github-com-adobe-helix-cli--master-dirty--
     directoryIndex: README.html
     content:
       repo: helix-cli
@@ -270,7 +270,7 @@ An example configuration could look like this:
 ```yaml
 strains:
   default:
-    code: /trieloff/default/https---github-com-adobe-helix-helpx-git--master--
+    code: /trieloff/default/github-com-adobe-helix-helpx--master--
     url: https://www.primordialsoup.life
     content:
       repo: reactor-user-docs
@@ -279,7 +279,7 @@ strains:
 
   develop:
     url: https://dev.primordialsoup.life/develop/
-    code: /trieloff/default/https---github-com-adobe-helix-helpx-git--develop--
+    code: /trieloff/default/github-com-adobe-helix-helpx--develop--
     content:
       repo: reactor-user-docs
       ref: master
@@ -297,7 +297,7 @@ You are still able to set strain `conditions` or assign traffic to a strain base
 ```yaml
 strains:
   default:
-    code: /trieloff/default/git-github-com-trieloff-helix-demo-git--dirty--
+    code: /trieloff/default/github-com-trieloff-helix-demo--master-dirty--
     content: https://github.com/trieloff/helix-demo.git
     static: https://github.com/trieloff/helix-demo.git
   oldcontent:
@@ -328,7 +328,7 @@ An example performance configuration might look like this:
 ```yaml
 strains:
   default:
-    code: /trieloff/default/https---github-com-adobe-helix-helpx-git--master--
+    code: /trieloff/default/github-com-adobe-helix-helpx--master--
     directoryIndex: README.html
     static:
       deny:

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -25,11 +25,6 @@ module.exports = function deploy() {
     command: 'deploy',
     desc: 'Deploy packaged functions to Adobe I/O runtime',
     builder: (yargs) => {
-      // eslint-disable-next-line global-require
-      const DeployCommand = require('./deploy.cmd'); // lazy load the handler to speed up execution time
-      // eslint-disable-next-line global-require
-      const { GitUtils } = require('@adobe/helix-shared'); // lazy load the handler to speed up execution time
-
       deployCommon(yargs);
       yargs
         .option('auto', {
@@ -74,7 +69,6 @@ module.exports = function deploy() {
         .option('prefix', {
           alias: 'p',
           describe: 'Prefix for the deployed action name.',
-          default: `${GitUtils.getRepository()}--${GitUtils.getBranchFlag()}--`,
         })
         .option('default', {
           describe: 'Adds a default parameter to the function',
@@ -94,7 +88,6 @@ module.exports = function deploy() {
         .option('content', {
           describe: 'Overrides the GitHub content URL of the default strain',
           type: 'string',
-          default: DeployCommand.getDefaultContentURL(),
         })
         .array('default')
         .nargs('default', 2)

--- a/test/testDeployCli.js
+++ b/test/testDeployCli.js
@@ -36,7 +36,6 @@ describe('hlx deploy', () => {
       return true;
     });
 
-
     mockDeploy = sinon.createStubInstance(DeployCommand);
     mockDeploy.withEnableAuto.returnsThis();
     mockDeploy.withCircleciAuth.returnsThis();
@@ -135,7 +134,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
     sinon.assert.calledWith(mockDeploy.withLogglyAuth, '');
     sinon.assert.calledWith(mockDeploy.withTarget, '.hlx/build');
     sinon.assert.calledWith(mockDeploy.withDocker, undefined);
-    sinon.assert.calledWith(mockDeploy.withPrefix, 'git-github-com-example-project-helix--master--');
+    sinon.assert.calledWith(mockDeploy.withPrefix, undefined);
     sinon.assert.calledWith(mockDeploy.withDefault, undefined);
     sinon.assert.calledWith(mockDeploy.withCreatePackages, 'auto');
     sinon.assert.calledOnce(mockDeploy.run);
@@ -158,7 +157,7 @@ Authentication is required. You can pass the key via the HLX_WSK_AUTH environmen
     sinon.assert.calledWith(mockDeploy.withLogglyAuth, '');
     sinon.assert.calledWith(mockDeploy.withTarget, '.hlx/build');
     sinon.assert.calledWith(mockDeploy.withDocker, undefined);
-    sinon.assert.calledWith(mockDeploy.withPrefix, 'git-github-com-example-project-helix--master--');
+    sinon.assert.calledWith(mockDeploy.withPrefix, undefined);
     sinon.assert.calledWith(mockDeploy.withDefault, undefined);
     sinon.assert.calledOnce(mockDeploy.run);
   });


### PR DESCRIPTION
fixes:
* Remove computed defaults from yargs options #231
* Use canonical action names independent of git origin #336
* [deploy] refuses to deploy with unintuitive error message if no remote git repo defined #413