### PR TITLE
OpenWhisk chokes on SVG if not base64 encoded

### DIFF
--- a/src/openwhisk/static.js
+++ b/src/openwhisk/static.js
@@ -58,7 +58,7 @@ function isBinary(type) {
     return false;
   }
   if (type.match(/.*\/.*xml/)) {
-    return false;
+    return !!type.match(/svg/); // openwshisk treats svg as binary
   }
   return true;
 }

--- a/test/testStatic.js
+++ b/test/testStatic.js
@@ -34,11 +34,12 @@ describe('Static Delivery Action #unittest', () => {
     assert.equal(index.isBinary('application/octet-stream'), true);
     assert.equal(index.isBinary('image/png'), true);
     assert.equal(index.isBinary('un/known'), true);
+    assert.equal(index.isBinary('image/svg+xml'), true);
 
     assert.equal(index.isBinary('text/html'), false);
+    assert.equal(index.isBinary('text/xml'), false);
     assert.equal(index.isBinary('application/json'), false);
     assert.equal(index.isBinary('application/javascript'), false);
-    assert.equal(index.isBinary('image/svg+xml'), false);
   });
 
   it('staticBase() #unittest', () => {


### PR DESCRIPTION
Fixes #507 
Fixes https://github.com/adobe/developer.adobe.com/issues/88