### PR TITLE
Stats + improved logging for errors

### DIFF
--- a/src/publish.cmd.js
+++ b/src/publish.cmd.js
@@ -201,7 +201,7 @@ class PublishCommand extends AbstractCommand {
       if (response.headers['fastly-ratelimit-remaining']) {
         this._stats['fastly-ratelimit-remaining'] = Math.min(
           response.headers['fastly-ratelimit-remaining'],
-          this._stats['fastly-ratelimit-remaining'] === 'N/A' ? Number.MAX_SAFE_INTEGER : this._stats['fastly-ratelimit-remaining']
+          this._stats['fastly-ratelimit-remaining'] === 'N/A' ? Number.MAX_SAFE_INTEGER : this._stats['fastly-ratelimit-remaining'],
         );
       }
       return Promise.resolve(response.body);
@@ -821,7 +821,7 @@ ${PublishCommand.makeParamWhitelist(params, '  ')}
     this.log.debug(` - Final 'fastly-ratelimit-remaining': ${this._stats['fastly-ratelimit-remaining']}`);
     this.log.debug(` - Number of strains published: ${this._stats.strainsPublished}`);
     this.log.debug(` - Number of missing dictionaries: ${this._stats.missingdicts}`);
-    this.log.debug(` - Number of dictionary entries processed (created or deleted): ${this._stats.dictionaryEntries}`)
+    this.log.debug(` - Number of dictionary entries processed (created or deleted): ${this._stats.dictionaryEntries}`);
   }
 
   async run() {

--- a/src/publish.cmd.js
+++ b/src/publish.cmd.js
@@ -345,7 +345,7 @@ class PublishCommand extends AbstractCommand {
     const existing = Object.entries(dictionaries).length - missingdicts.length;
     this.tick(existing, `Skipping ${existing} existing dictionaries`);
     if (missingdicts.length > 0) {
-      this.stats.missingdicts = missingdicts.length;
+      this._stats.missingdicts = missingdicts.length;
       const baseopts = await this.version('/dictionary');
       const fixdicts = missingdicts.map((dict) => {
         const opts = Object.assign({

--- a/test/testPublishCmd.js
+++ b/test/testPublishCmd.js
@@ -31,7 +31,7 @@ let WSK_NAMESPACE = '---';
 
 // const SRC_STRAINS = path.resolve(__dirname, 'fixtures/strains.yaml');
 
-describe('hlx strain #unit', () => {
+describe('hlx publish #unit', () => {
   it('makeRegexp() #unit', () => {
     const globs1 = ['*.htl', '*.js'];
     assert.equal(PublishCommand.makeRegexp(globs1), '^.*\\.htl$|^.*\\.js$');
@@ -204,5 +204,21 @@ describe('hlx publish (Integration)', function suite() {
     } catch (e) {
       assert.ok(e.message);
     }
+  });
+
+  it('Stats - requests', async () => {
+    const cmd = new PublishCommand()
+      .withDirectory(testRoot)
+      .withFastlyAuth(FASTLY_AUTH)
+      .withFastlyNamespace(FASTLY_NAMESPACE)
+      .withWskHost('adobeioruntime.net')
+      .withWskAuth(WSK_AUTH)
+      .withWskNamespace(WSK_NAMESPACE);
+    /* eslint-disable no-underscore-dangle */
+    assert.equal(cmd._stats.requests, 0);
+    await cmd._requestFastly(cmd.options(''));
+    assert.equal(cmd._stats.requests, 1);
+    await cmd._requestFastly(cmd.options(''));
+    assert.equal(cmd._stats.requests, 2);
   });
 });


### PR DESCRIPTION
While investigating for https://github.com/adobe/helix-cli/issues/510, I added some stats to debug. I though I could contribute this which helps tracing what the number of requests to Fastly. I also slightly improved the logs in case of error which were wrong. 
Stats are only visible when running: `hlx publish --log-level debug`

And look like this:

```
debug: Stats of the publish process:
debug:  - Number of requests to Fastly API: 122
debug:  - Final 'fastly-ratelimit-remaining': 34
debug:  - Number of strains published: 0
debug:  - Number of missing dictionaries: 0
debug:  - Number of dictionary entries processed (created or deleted): 223
```