### PR TITLE
Avoid conflicts with module-specific node_modules

### DIFF
--- a/src/package.cmd.js
+++ b/src/package.cmd.js
@@ -134,10 +134,11 @@ class PackageCommand extends AbstractCommand {
       Object.keys(info.externals).forEach((mod) => {
         // if a package (like request) brings its own node_modules directory, override it
         // so that conflicts with newer versions in the upper-level node_modules are avoided
-        if (mod==='ajv') {
-          info.externals[mod] = info.externals[mod].replace(/\/node_modules\/request\/node_modules\//, '/node_modules/');
+        if (mod === 'ajv') {
+          archive.directory(info.externals[mod].replace(/\/node_modules\/request\/node_modules\//, '/node_modules/')], `node_modules/${mod}`);
+        } else {
+          archive.directory(info.externals[mod], `node_modules/${mod}`);
         }
-        archive.directory(info.externals[mod], `node_modules/${mod}`);
         ticks[`node_modules/${mod}/package.json`] = true;
       });
 

--- a/src/package.cmd.js
+++ b/src/package.cmd.js
@@ -132,6 +132,11 @@ class PackageCommand extends AbstractCommand {
 
       // add modules that cause problems when embeded in webpack
       Object.keys(info.externals).forEach((mod) => {
+        // if a package (like request) brings its own node_modules directory, override it
+        // so that conflicts with newer versions in the upper-level node_modules are avoided
+        if (mod==='ajv') {
+          info.externals[mod] = info.externals[mod].replace(/\/node_modules\/request\/node_modules\//, '/node_modules/');
+        }
         archive.directory(info.externals[mod], `node_modules/${mod}`);
         ticks[`node_modules/${mod}/package.json`] = true;
       });

--- a/src/package.cmd.js
+++ b/src/package.cmd.js
@@ -132,13 +132,7 @@ class PackageCommand extends AbstractCommand {
 
       // add modules that cause problems when embeded in webpack
       Object.keys(info.externals).forEach((mod) => {
-        // if a package (like request) brings its own node_modules directory, override it
-        // so that conflicts with newer versions in the upper-level node_modules are avoided
-        if (mod === 'ajv') {
-          archive.directory(info.externals[mod].replace(/\/node_modules\/request\/node_modules\//, '/node_modules/'), `node_modules/${mod}`);
-        } else {
-          archive.directory(info.externals[mod], `node_modules/${mod}`);
-        }
+        archive.directory(info.externals[mod], `node_modules/${mod}`);
         ticks[`node_modules/${mod}/package.json`] = true;
       });
 

--- a/src/package.cmd.js
+++ b/src/package.cmd.js
@@ -135,7 +135,7 @@ class PackageCommand extends AbstractCommand {
         // if a package (like request) brings its own node_modules directory, override it
         // so that conflicts with newer versions in the upper-level node_modules are avoided
         if (mod === 'ajv') {
-          archive.directory(info.externals[mod].replace(/\/node_modules\/request\/node_modules\//, '/node_modules/')], `node_modules/${mod}`);
+          archive.directory(info.externals[mod].replace(/\/node_modules\/request\/node_modules\//, '/node_modules/'), `node_modules/${mod}`);
         } else {
           archive.directory(info.externals[mod], `node_modules/${mod}`);
         }

--- a/src/parcel/ExternalsCollector.js
+++ b/src/parcel/ExternalsCollector.js
@@ -69,11 +69,11 @@ class ExternalsCollector {
         stats.compilation.modules.forEach((mod) => {
           if (mod.resource) {
             const m = nodeModulesRegex.exec(mod.resource);
-            if (m && // there is a match
-              !this._excludes.has(m[2]) && // but it's not in externals
-              !externals[m[2]] && // and there is no path already registered
-              !m[0].match(/\/node_modules\/.*\/node_modules\//) // and it is not a nested node_module
-              ) {
+            if (m // there is a match
+              && !this._excludes.has(m[2]) // but it's not in externals
+              && !externals[m[2]] // and there is no path already registered
+              && !m[0].match(/\/node_modules\/.*\/node_modules\//) // and it is not a nested node_module
+            ) {
               externals[m[2]] = m[1] + m[2];
             }
           }

--- a/src/parcel/ExternalsCollector.js
+++ b/src/parcel/ExternalsCollector.js
@@ -69,7 +69,11 @@ class ExternalsCollector {
         stats.compilation.modules.forEach((mod) => {
           if (mod.resource) {
             const m = nodeModulesRegex.exec(mod.resource);
-            if (m && !this._excludes.has(m[2])) {
+            if (m && // there is a match
+              !this._excludes.has(m[2]) && // but it's not in externals
+              !externals[m[2]] && // and there is no path already registered
+              !m[0].match(/\/node_modules\/.*\/node_modules\//) // and it is not a nested node_module
+              ) {
               externals[m[2]] = m[1] + m[2];
             }
           }


### PR DESCRIPTION
This is a fix for https://github.com/adobe/helix-pipeline/issues/209 and potentially https://github.com/adobe/developer.adobe.com-planning/issues/183 caused by a version mismatch between ajv 5.x (used by `request`, supporting schema-6) and ajv 6.x (used by `helix-pipeline`, supporting schema-7`.

For `ajv` in particular, we use the global version instead of the version specific to `request`, assuming that the `har-validator` functionality is not used frequently.
