### PR TITLE
Enable remote publishing by default

### DIFF
--- a/src/publish.cmd.js
+++ b/src/publish.cmd.js
@@ -154,7 +154,7 @@ class PublishCommand extends AbstractCommand {
     return this;
   }
 
-  withPublishAPI(value) {
+  withPublishAPI(_) {
     // does not do anything here
     return this;
   }

--- a/src/publish.cmd.js
+++ b/src/publish.cmd.js
@@ -154,6 +154,11 @@ class PublishCommand extends AbstractCommand {
     return this;
   }
 
+  withPublishAPI(value) {
+    // does not do anything here
+    return this;
+  }
+
   withWskAuth(value) {
     this._wsk_auth = value;
     return this;

--- a/src/publish.js
+++ b/src/publish.js
@@ -43,7 +43,12 @@ module.exports = function strain() {
         .option('remote', {
           describe: 'Use the remote publishing service',
           type: 'boolean',
-          default: false,
+          default: true,
+        })
+        .option('api-publish', {
+          describe: 'API URL for helix-publish service',
+          type: 'string',
+          default: 'https://adobeioruntime.net/api/v1/web/helix/default/publish'
         })
         .demandOption(
           'fastly-auth',
@@ -75,6 +80,7 @@ module.exports = function strain() {
         .withFastlyNamespace(argv.fastlyNamespace)
         .withFastlyAuth(argv.fastlyAuth)
         .withDryRun(argv.dryRun)
+        .withPublishAPI(argv.apiPublish)
         .run();
     },
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -65,8 +65,8 @@ module.exports = function strain() {
     handler: async (argv) => {
       if (argv.remote) {
         // eslint-disable-next-line global-require
-        const PublishCommand = require('./remotepublish.cmd'); // lazy load the handler to speed up execution time
-        executor = executor || new PublishCommand(makeLogger(argv));
+        const RemotePublish = require('./remotepublish.cmd'); // lazy load the handler to speed up execution time
+        executor = executor || new RemotePublish(makeLogger(argv));
       } else {
         // eslint-disable-next-line global-require
         const PublishCommand = require('./publish.cmd'); // lazy load the handler to speed up execution time

--- a/src/publish.js
+++ b/src/publish.js
@@ -48,7 +48,7 @@ module.exports = function strain() {
         .option('api-publish', {
           describe: 'API URL for helix-publish service',
           type: 'string',
-          default: 'https://adobeioruntime.net/api/v1/web/helix/default/publish'
+          default: 'https://adobeioruntime.net/api/v1/web/helix/default/publish',
         })
         .demandOption(
           'fastly-auth',

--- a/src/remotepublish.cmd.js
+++ b/src/remotepublish.cmd.js
@@ -28,6 +28,7 @@ class RemotePublishCommand extends AbstractCommand {
     this._fastly_namespace = null;
     this._fastly_auth = null;
     this._dryRun = false;
+    this._publishAPI = 'https://adobeioruntime.net/api/v1/web/helix/default/publish';
   }
 
   tick(ticks = 1, message, name) {
@@ -59,6 +60,11 @@ class RemotePublishCommand extends AbstractCommand {
     });
 
     return this._bar;
+  }
+
+  withPublishAPI(value) {
+    this._publishAPI = value;
+    return this;
   }
 
   withWskHost(value) {
@@ -148,7 +154,7 @@ class RemotePublishCommand extends AbstractCommand {
   }
 
   servicePublish() {
-    return request.post('https://adobeioruntime.net/api/v1/web/helix/default/publish', {
+    return request.post(this._publishAPI, {
       json: true,
       body: {
         configuration: this.config.toJSON(),

--- a/test/testPublishCli.js
+++ b/test/testPublishCli.js
@@ -40,6 +40,7 @@ describe('hlx publish', () => {
     mockPublish.withFastlyNamespace.returnsThis();
     mockPublish.withFastlyAuth.returnsThis();
     mockPublish.withDryRun.returnsThis();
+    mockPublish.withPublishAPI.returnsThis();
     mockPublish.run.returnsThis();
   });
 
@@ -71,6 +72,7 @@ describe('hlx publish', () => {
         '--wsk-namespace', 'hlx',
         '--fastly-auth', 'secret-key',
         '--fastly-namespace', 'hlx',
+        '--remote', 'false'
       ]);
 
     sinon.assert.calledWith(mockPublish.withWskHost, 'adobeioruntime.net');
@@ -97,6 +99,7 @@ describe('hlx publish', () => {
     sinon.assert.calledWith(mockPublish.withWskNamespace, 'hlx');
     sinon.assert.calledWith(mockPublish.withFastlyNamespace, 'hlx'); // TODO !!
     sinon.assert.calledWith(mockPublish.withFastlyAuth, 'secret-key');
+    sinon.assert.calledWith(mockPublish.withPublishAPI, 'https://adobeioruntime.net/api/v1/web/helix/default/publish');
     sinon.assert.calledOnce(mockPublish.run);
   });
 });

--- a/test/testPublishCli.js
+++ b/test/testPublishCli.js
@@ -72,7 +72,7 @@ describe('hlx publish', () => {
         '--wsk-namespace', 'hlx',
         '--fastly-auth', 'secret-key',
         '--fastly-namespace', 'hlx',
-        '--remote', 'false'
+        '--remote', 'false',
       ]);
 
     sinon.assert.calledWith(mockPublish.withWskHost, 'adobeioruntime.net');

--- a/test/testPublishCmd.js
+++ b/test/testPublishCmd.js
@@ -167,6 +167,7 @@ describe('hlx publish (Integration)', function suite() {
       .withFastlyNamespace(FASTLY_NAMESPACE)
       .withWskHost('adobeioruntime.net')
       .withWskAuth(WSK_AUTH)
+      .withPublishAPI('https://adobeioruntime.net/api/v1/web/helix/default/publish')
       .withWskNamespace(WSK_NAMESPACE);
 
     // current version must 1

--- a/test/testRemotePublishCmd.js
+++ b/test/testRemotePublishCmd.js
@@ -55,6 +55,7 @@ describe('hlx publish --remote (default)', () => {
       .withFastlyAuth('fake_auth')
       .withFastlyNamespace('fake_name')
       .withWskHost('doesn.t.matter')
+      .withPublishAPI('https://adobeioruntime.net/api/v1/web/helix/default/publish')
       .withConfigFile(path.resolve(__dirname, 'fixtures/deployed.yaml'))
       .withDryRun(false);
     await remote.run();


### PR DESCRIPTION
 (still can be disabled using `--no-remote`) (see #401).

Enable setting the remote publish service URL using `--api-publish` (fixes #647)


Thanks for contributing!