### PR TITLE
feat(cli): check node version and report if not satisfied.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const ConfigUtils = require('./src/config/config-utils.js');
 require('dotenv').config();
 
 (async () => {
+  await ConfigUtils.checkNodeVersion();
   await ConfigUtils.validateDotEnv();
   new CLI().run(process.argv.slice(2));
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -5990,7 +5990,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6008,11 +6009,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6025,15 +6028,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6136,7 +6142,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6146,6 +6153,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6158,17 +6166,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6185,6 +6196,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6257,7 +6269,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6267,6 +6280,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6342,7 +6356,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6372,6 +6387,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6389,6 +6405,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6427,11 +6444,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5990,8 +5990,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6009,13 +6008,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6028,18 +6025,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6142,8 +6136,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6153,7 +6146,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6166,20 +6158,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6196,7 +6185,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6269,8 +6257,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6280,7 +6267,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6356,8 +6342,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6387,7 +6372,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6405,7 +6389,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6444,13 +6427,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "peerDependencies": {
     "isomorphic-git": "0.x"
   },
+  "engines": {
+    "node": ">=8.9 <9.0 || >=10.0 < 11.0"
+  },
   "dependencies": {
     "@adobe/fastly-native-promises": "^1.3.2",
     "@adobe/helix-pipeline": "1.1.1",
@@ -58,6 +61,7 @@
     "progress": "2.0.1",
     "request": "2.87.0",
     "request-promise-native": "1.0.7",
+    "semver": "^5.6.0",
     "shelljs": "0.8.2",
     "snyk": "1.143.1",
     "source-map": "0.7.3",

--- a/src/config/config-utils.js
+++ b/src/config/config-utils.js
@@ -57,7 +57,8 @@ which should never be stored in the git repository.
     if (!semver.satisfies(version, supported)) {
       stdout.write(`
 ${chalk.yellowBright('Warning:')} The current node version ${chalk.cyan(version)} does not satisfy 
-the supported version range ${chalk.cyan(supported)} and you might encounter unexpected errors.   
+the supported version range ${chalk.cyan(supported)}.
+You might encounter unexpected errors.   
 
 `);
     }

--- a/src/config/config-utils.js
+++ b/src/config/config-utils.js
@@ -13,7 +13,9 @@ const fs = require('fs-extra');
 const path = require('path');
 const chalk = require('chalk');
 const { GitUrl } = require('@adobe/helix-shared');
+const semver = require('semver');
 const GitUtils = require('../git-utils');
+const pkgJson = require('../../package.json');
 
 const DEFAULT_CONFIG = path.resolve(__dirname, 'default-config.yaml');
 
@@ -43,6 +45,22 @@ This is typically not good because it might contain secrets
 which should never be stored in the git repository.
 
 `);
+  }
+
+  /**
+   * Checks if the given version is supported.
+   * @param version {string} current node version
+   * @param stdout {WritableStream} to report the warninf
+   */
+  static checkNodeVersion(version = process.version, stdout = process.stdout) {
+    const supported = pkgJson.engines.node;
+    if (!semver.satisfies(version, supported)) {
+      stdout.write(`
+${chalk.yellowBright('Warning:')} The current node version ${chalk.cyan(version)} does not satisfy 
+the supported version range ${chalk.cyan(supported)} and you might encounter unexpected errors.   
+
+`);
+    }
   }
 }
 


### PR DESCRIPTION
fix #657

Adds a check to `hlx` for the current node version and reports a warning if version is not supported:

```
$ hlx

Warning: The current node version v8.3.0 does not satisfy
the supported version range >=8.9 <9.0 || >=10.0 < 11.0
You might encounter unexpected errors.
```
