### PR TITLE
fix(cli): setting --log-level and --log-file

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -66,12 +66,14 @@ function envAwareStrict(args, aliases) {
 function logArgs(argv) {
   return argv
     .option('log-file', {
+      alias: 'logFile',
       describe: 'Log file (use "-" for stdout)',
       type: 'string',
       array: true,
       default: '-',
     })
     .option('log-level', {
+      alias: 'logLevel',
       describe: 'Log level',
       type: 'string',
       choices: ['silly', 'debug', 'verbose', 'info', 'warn', 'error'],

--- a/test/testCli.js
+++ b/test/testCli.js
@@ -18,7 +18,10 @@ const assert = require('assert');
 const shell = require('shelljs');
 const path = require('path');
 const fse = require('fs-extra');
+const sinon = require('sinon');
 const pkgJson = require('../package.json');
+const CLI = require('../src/cli.js');
+
 const { createTestRoot } = require('./utils.js');
 const { checkNodeVersion } = require('../src/config/config-utils.js');
 
@@ -94,5 +97,27 @@ describe('hlx command line', () => {
         assert.ok(out.indexOf('does not satisfy \nthe supported version range') >= 0);
       }
     }
+  });
+
+  it('can set log-level and log-file', async () => {
+    const testCmd = {
+      command: 'test',
+      desc: 'Test Command.',
+      handler: sinon.spy(),
+    };
+    const cli = new CLI();
+    // eslint-disable-next-line no-underscore-dangle
+    cli._commands = {
+      test: testCmd,
+    };
+    await cli.run(['test', '--log-level', 'silly', '--log-file', 'foo.log']);
+    sinon.assert.calledWith(testCmd.handler, {
+      $0: 'hlx',
+      _: ['test'],
+      'log-file': ['foo.log'],
+      'log-level': 'silly',
+      logFile: ['foo.log'],
+      logLevel: 'silly',
+    });
   });
 });


### PR DESCRIPTION
Due to the changes for the `.env` file support, the `--log-level` and `--log-file`
arguments didn't work anymore. fixed by defining their camelCase aliases manually.

fixes #756