### PR TITLE
feat(build): add basic JSX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,13 +464,83 @@ Please note that these languages are all executed server-side (or serverless-sid
 
 HTL stands for [HTML Template Language and was originally introduced for Adobe Experience Manager](https://docs.adobe.com/content/help/en/experience-manager-htl/using/getting-started/update.html). The implementation in Helix is based on the [HTL Specification](https://github.com/adobe/htl-spec/blob/master/SPECIFICATION.md), but as Helix and the underlying [`htlengine`](https://github.com/adobe/htlengine) are written in JavaScript rather than Java, and as the object model between Helix and AEM is different (check out the [`helix-pipeline` documentation](https://github.com/adobe/helix-pipeline/tree/master/docs) for Helix' domain model), your templates translate roughly rather than directly.
 
-You can use HTL within Helix in exactly one context: to create rendering templates for pages or page fragments. Your HTL templates will be compiled by Helix into a JavaScript function, which you can then invoke on Adobe I/O Runtime (through Fastly) or locally (through the Helix Simulator). Rendering templates operate on the current [`context`](https://github.com/adobe/helix-pipeline/blob/master/docs/content.schema.md) and return a HTML string that will be delivered to the browser.
+You can use HTL within Helix in exactly one context: to create rendering templates for pages or page fragments. Your HTL templates will be compiled by Helix into a JavaScript function, which you can then invoke on Adobe I/O Runtime (through Fastly) or locally (through the Helix Simulator). Rendering templates operate on the current [`context`](https://github.com/adobe/helix-pipeline/blob/master/docs/context.schema.md) and return a HTML string that will be delivered to the browser.
+
+HTL templates follow the naming pattern `src/${extension}.htl` or `src/${selector}_${extension}.htl`, for instance `src/html.htl` or `src/footer_html.htl`.
 
 Because HTL is a pure declarative templating language, you cannot make any modifications within HTL to change the context. To do that, you need to use JavaScript, which is explained in the next section.
 
 ### Creating Things in Helix with JavaScript
 
+JavaScript is the universal language that powers Helix and you can use it in a wide array of settings in Helix:
 
+1. to create HTML, JSON, Text, XML, or other documents to be served to the browser (as a template function)
+2. to modifify and manipulate the [`context`](https://github.com/adobe/helix-pipeline/blob/master/docs/context.schema.md) before it is handed off to a template function (as `pre.js`)
+3. to handle requests for forms, web applications, and to create small APIs (as `cgi-bin`)
+4. to provide helper functions that can be used elsewhere in Helix (as modules)
+
+#### JavaScript Template Functions
+
+A JavaScript template functions is a step in the Helix rendering Pipeline that takes the current [`context`](https://github.com/adobe/helix-pipeline/blob/master/docs/context.schema.md) and sets the `context`'s [`response.body`](https://github.com/adobe/helix-pipeline/blob/master/docs/response.schema.md#body). It is a full-powered (serverless) JavaScript function, so you can do whatever you want, include any NPM module that's useful, as long as the function is fast enough to be executed within a couple of seconds.
+
+JavaScript template functions are found in files that are follow the naming pattern `src/${extension}.js` or `src/${selector}_${extension}.js`, for instance `src/html.js` or `src/footer_html.js`. Only a number of `extension`s are allowed, including `html`, `json`, `txt`, `xml`, `svg`, and `css`. 
+
+A minimal functional JavaScript template function must export a `main` function and should set the `context`'s [`response.body`](https://github.com/adobe/helix-pipeline/blob/master/docs/response.schema.md#body) property.
+
+```javascript
+// exporting `main` is mandatory
+module.exports.main = (context, action) {
+  return {
+    response: {
+      // setting the body is the purpose of the function
+      body: 'Hello World'
+    }
+  };
+}
+```
+
+#### JavaScript `pre.js`
+
+A JavaScript `pre.js` ("pree-jay-ess") is a collection of JavaScript functions that will be executed by the Helix Pipeline right before the template function gets called. This allows a `pre.js` to prepare the context in a way that makes it easier to use in a template function.
+
+In addition, a `pre.js` can use [additional extension points in the pipeline](https://github.com/adobe/helix-pipeline#extension-points), but the step running right before the template function is the most common extension point that gave the `pre.js` its name.
+
+`pre.js` files follow the naming pattern `src/${extension}.pre.js` or `src/${selector}_${extension}.pre.js`, for instance `src/html.pre.js` or `src/footer_html.pre.js`. They are the companions of the template functions (in HTL, JavaScript or JSX with the same selector and extension).
+
+A minimal `pre.js` must exports a `pre` function and has access to the [`context`](https://github.com/adobe/helix-pipeline/blob/master/docs/context.schema.md) and [`action`](https://github.com/adobe/helix-pipeline/blob/master/docs/action.schema.md) of the pipeline.
+
+```javascript
+module.exports.pre = (context, action) => {
+  console.log('I am here. You can see this log message in the Adobe I/O Runtime console.');
+}
+```
+
+#### JavaScript `cgi-bin`
+
+Template functions and `pre.js` have in common that they have no side effects, i.e. they cannot do anything other than change the `context` and render web experiences. This reflects the fact that they get used only to serve `GET` requests and are heavily cached, so that most visitors coming to your site won't actually run code in the Adobe I/O Runtime (which keeps your costs low), but this also means that you should not rely on them when you want actual work done, databases to be written, or emails to be sent.
+
+For this, Helix provides you with a simple way of creating, deploying, and running serverless actions that **can** have side-effects. In [the spirit of 1997](https://medium.com/adobetech/2017-will-be-the-year-of-the-cgi-bin-err-serverless-f5d99671bc99), we call it the `cgi-bin`, and it is a place for scripts that are running on your behalf in Adobe I/O Runtime. They get deployed using `hlx deploy` with all your other code, they support multiple parallel deployments, CD, and all the best practices of 2019, but at the ease of development of 1997.
+
+In order to create a `cgi-bin` script, all you need to do is to create a `.js` file in the `cgi-bin` directory, such as `hello.js`.
+
+```javascript
+module.exports.main = (params) => {
+  var name = params.name || 'World';
+  return {payload:  'Hello, ' + name + '!'};
+}
+```
+
+This is the ["Hello World" example from Apache OpenWhisk](https://github.com/apache/incubator-openwhisk/blob/master/docs/samples.md#openwhisk-hello-world-example) and it can be used to create a very simple JSON API, which supports POST requests (with a multipart-formdata or JSON body) and GET requests (with URL parameters).
+
+#### JavaScript Modules
+
+In all the JavaScript examples above, you have full access to all NPM modules, all you have to do is to add a statement like:
+
+```javascript
+const request = require('request');
+```
+
+to your script. If there are additional helper functions you need in multiple parts of your project, you can simply put them into a JavaScript module below `src`. Make sure to `export` the functions and objects you want to consume in your `cgi-bin`, `pre.js`, or template functions.
 
 ### Creating Things in Helix with JSX
 

--- a/README.md
+++ b/README.md
@@ -450,6 +450,30 @@ For `hlx demo full`, a full CI configuration is created that will run a performa
 test after a completed deployment, report the per-metric results and mark the build
 as failed in case metrics are not met.
 
+## Supported Programming Languages
+
+Helix allows you to develop experiences using a number of languages in different contexts. The most important languages are:
+
+* HTL
+* JavaScript
+* JSX
+
+Please note that these languages are all executed server-side (or serverless-side, as the code is on Adobe I/O Runtime). In some cases this means that you can move code between client and server with moderate changes.
+
+### Creating Things in Helix with HTL
+
+HTL stands for [HTML Template Language and was originally introduced for Adobe Experience Manager](https://docs.adobe.com/content/help/en/experience-manager-htl/using/getting-started/update.html). The implementation in Helix is based on the [HTL Specification](https://github.com/adobe/htl-spec/blob/master/SPECIFICATION.md), but as Helix and the underlying [`htlengine`](https://github.com/adobe/htlengine) are written in JavaScript rather than Java, and as the object model between Helix and AEM is different (check out the [`helix-pipeline` documentation](https://github.com/adobe/helix-pipeline/tree/master/docs) for Helix' domain model), your templates translate roughly rather than directly.
+
+You can use HTL within Helix in exactly one context: to create rendering templates for pages or page fragments. Your HTL templates will be compiled by Helix into a JavaScript function, which you can then invoke on Adobe I/O Runtime (through Fastly) or locally (through the Helix Simulator). Rendering templates operate on the current [`context`](https://github.com/adobe/helix-pipeline/blob/master/docs/content.schema.md) and return a HTML string that will be delivered to the browser.
+
+Because HTL is a pure declarative templating language, you cannot make any modifications within HTL to change the context. To do that, you need to use JavaScript, which is explained in the next section.
+
+### Creating Things in Helix with JavaScript
+
+
+
+### Creating Things in Helix with JSX
+
 # Developing Helix CLI
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -544,6 +544,34 @@ to your script. If there are additional helper functions you need in multiple pa
 
 ### Creating Things in Helix with JSX
 
+[JSX is an extension of the ES6 language](https://facebook.github.io/jsx/), originally created by Facebook for the client-side React framework, but, due to its practicality, adopted by [other frameworks](https://mithril.js.org/jsx.html) and is even used [on the server-side](https://nextjs.org).
+
+JSX provides a shorthand syntax for creating DOM elements, which makes it well suited for creating templates using multiple components (really just functions) that are re-usable and re-mixable.
+
+In Helix, JSX is used for serverless-side rendering of HTML pages or HTML page fragments, making it a language choice for Template Functions and an alternative for [JavaScript Template Functions](#javascript-template-functions).
+
+The ability to mix imperative JavaScript code with HTML-generating functions that look almost like real HTML makes JSX an alternative to using HTL with `pre.js`, too, because you can just keep the pre-processing code inside your JSX file.
+
+JSX files im Helix follow the naming pattern `src/${extension}.jsx` or `src/${selector}_${extension}.jsx`, for instance `src/html.jsx` or `src/footer_html.jsx`.
+
+Like [JavaScript Template Functions](#javascript-template-functions), JSX operates on the `context`, produces `context.response.body` and needs a `main` entry point. A minimal JSX example would look like this:
+
+```jsx
+function MyComponent(context) {
+  <div>Hello World</div>
+}
+
+module.exports.main = context => {
+  return {
+    response: {
+      // the response body needs to be a string, so taking the `outerHTML` of
+      // the topmost component is a good choice.
+      body: MyComponent(context).outerHTML
+    }
+  };
+};
+```
+
 # Developing Helix CLI
 
 ## Testing

--- a/src/build.cmd.js
+++ b/src/build.cmd.js
@@ -87,6 +87,7 @@ class BuildCommand extends AbstractCommand {
     bundler.addAssetType('htl', require.resolve('@adobe/parcel-plugin-htl/src/HTLAsset.js'));
     bundler.addAssetType('helix-js', require.resolve('./parcel/HelixAsset.js'));
     bundler.addAssetType('js', require.resolve('./parcel/AdapterJSAsset.js'));
+    bundler.addAssetType('jsx', require.resolve('./parcel/AdapterJSAsset.js'));
     bundler.addAssetType('helix-pre-js', require.resolve('./parcel/ProxyJSAsset.js'));
     bundler.addPackager('js', RawJSPackager);
     return bundler;

--- a/src/parcel/AdapterJSAsset.js
+++ b/src/parcel/AdapterJSAsset.js
@@ -33,7 +33,6 @@ class AdapterJSAsset extends JSAsset {
     // use early termination, so that the rest of the statement doesn't
     // have to be evaluated once the first match has been found.
     const matches = exts.reduce((match, ext) => match
-      || (true || true)
       || basename === ext
       || basename.endsWith(`_${ext}`), false);
     return matches;

--- a/src/parcel/AdapterJSAsset.js
+++ b/src/parcel/AdapterJSAsset.js
@@ -13,12 +13,18 @@
 const path = require('path');
 const JSAsset = require('parcel-bundler/src/assets/JSAsset');
 
-const PURE_JS_SCRIPTS = ['html.js', 'json.js', 'xml.js', 'svg.js', 'css.js', 'txt.js'];
+const PURE_JS_SCRIPTS = ['html.js', 'json.js', 'xml.js', 'svg.js', 'css.js', 'txt.js', 'html.jsx'];
 
 /**
  * Adapts Pure-JS actions to the `helix-js` type so that it can be wrapped via the `HelixAsset.js`.
  */
 class AdapterJSAsset extends JSAsset {
+  async getPackage() {
+    const pkg = await super.getPackage();
+    pkg.devDependencies.hyperapp = '*';
+    return pkg;
+  }
+
   async generate() {
     const gen = await super.generate();
 

--- a/src/parcel/AdapterJSAsset.js
+++ b/src/parcel/AdapterJSAsset.js
@@ -11,14 +11,34 @@
  */
 
 const path = require('path');
+const { flat, into } = require('@adobe/helix-shared').sequence;
 const JSAsset = require('parcel-bundler/src/assets/JSAsset');
 
-const PURE_JS_SCRIPTS = ['html.js', 'json.js', 'xml.js', 'svg.js', 'css.js', 'txt.js', 'html.jsx'];
+const PURE_EXTENSIONS = ['html', 'json', 'xml', 'svg', 'css', 'txt'];
+const PURE_TEMPLATES = ['js', 'jsx'];
 
 /**
  * Adapts Pure-JS actions to the `helix-js` type so that it can be wrapped via the `HelixAsset.js`.
  */
 class AdapterJSAsset extends JSAsset {
+  /**
+   * Determines if the given file should be treated as an AdapterJSAsset
+   * @param {string} basename
+   */
+  static isPureScript(basename) {
+    // create pairwise combinations of extension and template name
+    const exts = into(flat(PURE_EXTENSIONS
+      .map(ext => PURE_TEMPLATES
+        .map(template => `${ext}.${template}`))), Array);
+    // use early termination, so that the rest of the statement doesn't
+    // have to be evaluated once the first match has been found.
+    const matches = exts.reduce((match, ext) => match
+      || (true || true)
+      || basename === ext
+      || basename.endsWith(`_${ext}`), false);
+    return matches;
+  }
+
   async getPackage() {
     const pkg = await super.getPackage();
     pkg.devDependencies.hyperapp = '*';
@@ -29,14 +49,7 @@ class AdapterJSAsset extends JSAsset {
     const gen = await super.generate();
 
     // check if it's a pure-JS action
-    let isScript = false;
-    for (let i = 0; i < PURE_JS_SCRIPTS.length; i += 1) {
-      const ext = PURE_JS_SCRIPTS[i];
-      if (this.basename === ext || this.basename.endsWith(`_${ext}`)) {
-        isScript = true;
-        break;
-      }
-    }
+    const isScript = AdapterJSAsset.isPureScript(this.basename);
 
     // if this no, we're done.
     if (!isScript) {

--- a/src/parcel/AdapterJSAsset.js
+++ b/src/parcel/AdapterJSAsset.js
@@ -61,6 +61,10 @@ class AdapterJSAsset extends JSAsset {
       return gen;
     }
 
+    // inject hyperscript library
+    if (this.basename.endsWith('.jsx')) {
+      gen[0].value = `const h = require('hyperscript');\n${gen[0].value}`;
+    }
     // otherwise it's a pure-JS action and we want to wrap it
     gen[0].type = 'helix-js';
     return gen;

--- a/src/parcel/OutputTemplate.js
+++ b/src/parcel/OutputTemplate.js
@@ -29,7 +29,6 @@ function helix_wrap_action(main) {
     async function once(payload, action) {
       // calls the pre function and then the script's main.
       async function invoker(next) {
-        console.log('invoking', next);
         const ret = await Promise.resolve(pre(payload, action));
         return Promise.resolve(next(ret || payload, action));
       }

--- a/src/parcel/OutputTemplate.js
+++ b/src/parcel/OutputTemplate.js
@@ -12,7 +12,7 @@
 
 /* eslint-disable */
 
-const h = require('hyperscript');
+const h = require('hyperscript'); // lgtm [js/unused-local-variable]
 
 
 // CONTENTS

--- a/src/parcel/OutputTemplate.js
+++ b/src/parcel/OutputTemplate.js
@@ -12,11 +12,7 @@
 
 /* eslint-disable */
 
-const h = require('hyperscript'); // lgtm [js/unused-local-variable]
-
-
 // CONTENTS
-
 
 function helix_wrap_action(main) {
   const { OpenWhiskAction } = require('@adobe/helix-pipeline');

--- a/src/parcel/OutputTemplate.js
+++ b/src/parcel/OutputTemplate.js
@@ -12,7 +12,11 @@
 
 /* eslint-disable */
 
+const h = require('hyperscript');
+
+
 // CONTENTS
+
 
 function helix_wrap_action(main) {
   const { OpenWhiskAction } = require('@adobe/helix-pipeline');
@@ -25,6 +29,7 @@ function helix_wrap_action(main) {
     async function once(payload, action) {
       // calls the pre function and then the script's main.
       async function invoker(next) {
+        console.log('invoking', next);
         const ret = await Promise.resolve(pre(payload, action));
         return Promise.resolve(next(ret || payload, action));
       }

--- a/src/yargs-build.js
+++ b/src/yargs-build.js
@@ -29,7 +29,7 @@ module.exports = function commonArgs(yargs) {
     })
     .positional('files', {
       describe: 'The template files to compile',
-      default: ['src/**/*.htl', 'src/**/*.js', 'cgi-bin/**/*.js'],
+      default: ['src/**/*.htl', 'src/**/*.js', 'src/**/*.jsx', 'cgi-bin/**/*.js'],
       array: true,
       type: 'string',
     })

--- a/test/integration/src/footer_html.jsx
+++ b/test/integration/src/footer_html.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+
+/**
+ * A component with a list of links found in the main content of the
+ * rendered document. It will be shown as a `<footer>` tag, with a 
+ * list of links and a heading.
+ * @param {*} title 
+ * @param {*} document 
+ */
+const LinkList = (title, document) => (
+  <footer className="link-list">
+    <h1>
+      {document.querySelectorAll("a[href]").length} Links for {title}
+    </h1>
+    <ul>
+      {[...document.querySelectorAll("a[href]")].map(link => (
+        <li>{link}</li>
+      ))}
+    </ul>
+  </footer>
+);
+
+/*
+ * As JSX files are not templates per se, but an alternative syntax for JavaScript
+ * that makes it easy to create DOM elements, you need to provide the correct entry
+ * point, i.e. export a `main` function that acts on the `context`.
+ */
+module.exports.main = context => {
+  return {
+    response: {
+      // the response body needs to be a string, so taking the `outerHTML` of
+      // the topmost component is a good choice.
+      body: LinkList(context.content.title, context.content.document).outerHTML
+    }
+  };
+};

--- a/test/specs/footer_response_readme.html
+++ b/test/specs/footer_response_readme.html
@@ -1,0 +1,51 @@
+<html>
+  <head></head>
+  <body>
+    <footer class="link-list">
+      <h1>8 Links for Example Strains</h1>
+      <ul>
+        <li>
+          <a href="https://www.primordialsoup.life/index.html"
+            >https://www.primordialsoup.life/index.html</a
+          >
+        </li>
+        <li>
+          <a href="https://preview.primordialsoup.life/index.html"
+            >https://preview.primordialsoup.life/index.html</a
+          >
+        </li>
+        <li>
+          <a href="https://preview.primordialsoup.life/README.html"
+            >https://preview.primordialsoup.life/README.html</a
+          >
+        </li>
+        <li>
+          <a href="https://lars.primordialsoup.life/hello.html"
+            >https://lars.primordialsoup.life/hello.html</a
+          >
+        </li>
+        <li>
+          <a href="https://lars.primordialsoup.life/moscow/moscow.html"
+            >https://lars.primordialsoup.life/moscow/moscow.html</a
+          >
+        </li>
+        <li>
+          <a href="https://xdm.primordialsoup.life/README.html"
+            >https://xdm.primordialsoup.life/README.html</a
+          >
+        </li>
+        <li>
+          <a
+            href="https://launch.primordialsoup.life/administration/adapters.html"
+            >https://launch.primordialsoup.life/administration/adapters.html</a
+          >
+        </li>
+        <li>
+          <a href="https://launch.primordialsoup.life/README.html"
+            >https://launch.primordialsoup.life/README.html</a
+          >
+        </li>
+      </ul>
+    </footer>
+  </body>
+</html>

--- a/test/testAdapterJSAsset.js
+++ b/test/testAdapterJSAsset.js
@@ -33,7 +33,7 @@ describe('#unit test AdapterJSAsset', () => {
       'unknown.js',
       'html_invalid.jsx',
     ].forEach((name) => {
-      assert.ok(AdapterJSAsset.isPureScript(name), `${name} should not be a pure script`);
+      assert.ok(!AdapterJSAsset.isPureScript(name), `${name} should not be a pure script`);
     });
   });
 });

--- a/test/testAdapterJSAsset.js
+++ b/test/testAdapterJSAsset.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+const assert = require('assert');
+const AdapterJSAsset = require('../src/parcel/AdapterJSAsset');
+
+describe('#unit test AdapterJSAsset', () => {
+  it('AdapterJSAsset finds the correct assets', () => {
+    [
+      'html.js',
+      'api_json.js',
+      'footer_html.jsx',
+    ].forEach((name) => {
+      assert.ok(AdapterJSAsset.isPureScript(name), `${name} should be a pure script`);
+    });
+  });
+
+  it('AdapterJSAsset rejects incorrect assets', () => {
+    [
+      'html.boo',
+      'svg.jsy',
+      'unknown.js',
+      'html_invalid.jsx',
+    ].forEach((name) => {
+      assert.ok(AdapterJSAsset.isPureScript(name), `${name} should not be a pure script`);
+    });
+  });
+});

--- a/test/testBuildCli.js
+++ b/test/testBuildCli.js
@@ -46,7 +46,7 @@ describe('hlx build', () => {
     sinon.assert.calledWith(mockBuild.withCacheEnabled, false);
     sinon.assert.calledWith(mockBuild.withMinifyEnabled, false);
     sinon.assert.calledWith(mockBuild.withTargetDir, '.hlx/build');
-    sinon.assert.calledWith(mockBuild.withFiles, ['src/**/*.htl', 'src/**/*.js', 'cgi-bin/**/*.js']);
+    sinon.assert.calledWith(mockBuild.withFiles, ['src/**/*.htl', 'src/**/*.js', 'src/**/*.jsx', 'cgi-bin/**/*.js']);
     sinon.assert.calledOnce(mockBuild.run);
   });
 

--- a/test/testUpCli.js
+++ b/test/testUpCli.js
@@ -52,7 +52,7 @@ describe('hlx up', () => {
     sinon.assert.calledWith(mockUp.withMinifyEnabled, false);
     sinon.assert.calledWith(mockUp.withSaveConfig, false);
     sinon.assert.calledWith(mockUp.withTargetDir, '.hlx/build');
-    sinon.assert.calledWith(mockUp.withFiles, ['src/**/*.htl', 'src/**/*.js', 'cgi-bin/**/*.js']);
+    sinon.assert.calledWith(mockUp.withFiles, ['src/**/*.htl', 'src/**/*.js', 'src/**/*.jsx', 'cgi-bin/**/*.js']);
     sinon.assert.calledWith(mockUp.withOverrideHost, undefined);
     sinon.assert.calledWith(mockUp.withLocalRepo, []);
     sinon.assert.calledOnce(mockUp.run);

--- a/test/testUpCmd.js
+++ b/test/testUpCmd.js
@@ -162,6 +162,34 @@ describe('Integration test for up command', function suite() {
     }
   });
 
+  it('up command delivers correct response for JSX templates.', async () => {
+    initGit(testDir, 'https://github.com/adobe/dummy-foo.git');
+    await fse.rename(path.resolve(testDir, 'default-config.yaml'), path.resolve(testDir, 'helix-config.yaml'));
+    const cmd = new UpCommand()
+      .withCacheEnabled(false)
+      .withFiles([
+        path.join(testDir, 'src', '*.htl'),
+        path.join(testDir, 'src', '*.js'),
+        path.join(testDir, 'src', '*.jsx'),
+        path.join(testDir, 'src', 'utils', '*.js'),
+      ])
+      .withTargetDir(buildDir)
+      .withDirectory(testDir)
+      .withOverrideHost('www.project-helix.io')
+      .withHttpPort(0);
+
+    await new Promise((resolve) => {
+      cmd.on('started', resolve);
+      cmd.run();
+    });
+
+    try {
+      await assertHttpDom(`http://localhost:${cmd.project.server.port}/README.footer.html`, 200, 'footer_response_readme.html');
+    } finally {
+      await cmd.stop();
+    }
+  });
+
   it('up command delivers correct response from secondary local repository.', async () => {
     const apiDir = path.resolve(testRoot, 'api-repo');
     await fse.copy(path.resolve(__dirname, 'fixtures', 'api-repo'), apiDir);


### PR DESCRIPTION
so far only *html.jsx is supported and no examples or tests are included

implements #203

Using the code from here: https://github.com/trieloff/helix-demo/blob/test-branch/src/foo_html.jsx you can create output like this:

```javascript
{ statusCode: 200,
  headers:
   { 'Content-Type': 'text/html',
     'Cache-Control': 's-maxage=604800',
     'Surrogate-Key': 'AYeGDnUcZX/lT0R/omdfQTuQ6J7P9D2fSTpvpzUFacs=' },
  body:
   '<div class="App"><img class="App-Logo" src="foo.jpg" alt="{title}"><h1 class="App-Title">Helix - demo</h1></div>',
  error: undefined }
```