### PR TITLE
fix(package): add more modules to packager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8955,6 +8955,11 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
+    "ip-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
+    },
     "ipaddr.js": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
@@ -12730,7 +12735,7 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
@@ -13091,7 +13096,7 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "hyperscript": "^2.0.2",
     "ignore": "^5.1.0",
     "ini": "^1.3.5",
+    "ip-regex": "^4.1.0",
     "junit-report-builder": "1.3.1",
     "lodash": "4.17.11",
     "mime-types": "2.1.24",
@@ -77,6 +78,7 @@
     "uri-js": "4.2.2",
     "uuid": "3.3.2",
     "webpack": "4.33.0",
+    "xregexp": "^4.2.4",
     "yargs": "13.2.2"
   },
   "devDependencies": {
@@ -110,8 +112,7 @@
     "proxyquire": "^2.1.0",
     "semantic-release": "^15.13.12",
     "sinon": "7.3.2",
-    "unzip2": "0.2.5",
-    "xregexp": "^4.2.4"
+    "unzip2": "0.2.5"
   },
   "snyk": true,
   "lint-staged": {

--- a/src/parcel/packager-config.js
+++ b/src/parcel/packager-config.js
@@ -17,7 +17,7 @@ module.exports = {
     openwhisk: '3.18.0',
     'body-parser': '1.18.3',
     'cls-hooked': '4.2.2',
-    request: '2.88.0',
+    // request: '2.88.0',
     'request-promise': '4.2.2',
 
     // webpack isn't really provided by the container, but it injects itself into the list of


### PR DESCRIPTION
fixes #966

**Note**: This is not a very satisfying fix. the problem here is really, to determine the minimal set of node modules to run this in production, w/o relying on the dev-dependencies.


