### PR TITLE
chore: Use renovatebot

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,5 +119,18 @@
     "ghooks": {
       "pre-commit": "npx lint-staged"
     }
+  },
+  "renovate": {
+    "extends": [
+      "config:base"
+    ],
+    "schedule": "at 07:00 pm on Monday",
+    "timezone": "Europe/Zurich",
+    "packageRules": [
+      {
+        "packagePatterns": [".*"],
+        "groupName": "any"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Somebody with admin access on github/adobe still needs to install the renovatebot on the repo.
https://github.com/marketplace/renovate