### PR TITLE
refactor(cli): rename fastly-namespace

### DIFF
--- a/src/publish.js
+++ b/src/publish.js
@@ -25,7 +25,7 @@ module.exports = function strain() {
       executor = value;
     },
     command: ['publish'],
-    desc: 'Activate strains in the Fastly CDN and publish the site',
+    desc: 'Activate strains in the Fastly CDN and publish the site.',
     builder: (yargs) => {
       yargsOpenwhisk(yargs);
       yargsFastly(yargs);
@@ -33,19 +33,19 @@ module.exports = function strain() {
       yargs
         .option('dry-run', {
           alias: 'dryRun',
-          describe: 'List the actions that would be created, but do not actually deploy',
+          describe: 'List the actions that would be created, but do not actually deploy.',
           type: 'boolean',
           default: false,
         })
         .option('api-publish', {
           alias: 'apiPublish',
-          describe: 'API URL for helix-publish service',
+          describe: 'API URL for helix-publish service.',
           type: 'string',
           default: 'https://adobeioruntime.net/api/v1/web/helix/helix-services/publish@v2',
         })
         .option('api-config-purge', {
           alias: 'apiConfigPurge',
-          describe: 'API URL for helix bot config service',
+          describe: 'API URL for helix bot config service.',
           type: 'string',
           default: 'https://app.project-helix.io/config/purge',
         })
@@ -55,11 +55,11 @@ module.exports = function strain() {
           type: 'boolean',
         })
         .option('only', {
-          describe: 'Only publish strains with names following the specified pattern, use config from master branch for all others',
+          describe: 'Only publish strains with names following the specified pattern, use config from master branch for all others.',
           type: 'string',
         })
         .option('exclude', {
-          describe: 'Don\'t publish strains with names following the specified pattern, use config from master branch instead',
+          describe: 'Don\'t publish strains with names following the specified pattern, use config from master branch instead.',
           type: 'string',
         })
         .option('custom-vcl', {
@@ -77,11 +77,11 @@ module.exports = function strain() {
         .conflicts('only', 'exclude')
         .demandOption(
           'fastly-auth',
-          'Authentication is required. You can pass the key via the HLX_FASTLY_AUTH environment variable, too',
+          'Authentication is required. You can pass the key via the HLX_FASTLY_AUTH environment variable, too.',
         )
         .demandOption(
-          'fastly-namespace',
-          'Fastly Service ID is required',
+          'fastly-serviceid',
+          'Fastly Service ID is required.',
         )
         .check((args) => {
           if (args.githubToken && args.updateBotConfig === undefined) {
@@ -94,7 +94,7 @@ module.exports = function strain() {
           }
           return true;
         })
-        .group(['wsk-auth', 'wsk-namespace', 'fastly-auth', 'fastly-namespace'], 'Deployment Options')
+        .group(['wsk-auth', 'wsk-namespace', 'fastly-auth', 'fastly-serviceid'], 'Deployment Options')
         .group(['wsk-host', 'dry-run'], 'Advanced Options')
         .group(['github-token', 'update-bot-config'], 'Helix Bot Options')
         .help();

--- a/src/yargs-fastly.js
+++ b/src/yargs-fastly.js
@@ -12,9 +12,9 @@
 
 module.exports = function commonArgs(yargs) {
   return yargs
-    .option('fastly-namespace', {
-      alias: 'fastlyNamespace',
-      describe: 'CDN Namespace (e.g. Fastly Service ID)',
+    .option('fastly-serviceid', {
+      alias: ['fastlyNamespace', 'fastly-namespace'],
+      describe: 'CDN Namespace (e.g. Fastly Service ID).',
       type: 'string',
     })
     .option('fastly-auth', {

--- a/src/yargs-fastly.js
+++ b/src/yargs-fastly.js
@@ -13,7 +13,7 @@
 module.exports = function commonArgs(yargs) {
   return yargs
     .option('fastly-serviceid', {
-      alias: ['fastlyNamespace', 'fastly-namespace'],
+      alias: ['fastlyNamespace', 'fastly-namespace', 'fastlyServiceid'],
       describe: 'CDN Namespace (e.g. Fastly Service ID).',
       type: 'string',
     })

--- a/test/testPublishCli.js
+++ b/test/testPublishCli.js
@@ -97,6 +97,26 @@ describe('hlx publish', () => {
     sinon.assert.calledOnce(mockPublish.run);
   });
 
+  it('hlx publish works with minimal arguments with serviceid', () => {
+    new CLI()
+      .withCommandExecutor('publish', mockPublish)
+      .run(['publish',
+        '--wsk-auth', 'secret-key',
+        '--wsk-namespace', 'hlx',
+        '--fastly-auth', 'secret-key',
+        '--fastly-serviceid', 'hlx',
+      ]);
+
+    sinon.assert.calledWith(mockPublish.withWskHost, 'adobeioruntime.net');
+    sinon.assert.calledWith(mockPublish.withWskAuth, 'secret-key');
+    sinon.assert.calledWith(mockPublish.withWskNamespace, 'hlx');
+    sinon.assert.calledWith(mockPublish.withFastlyNamespace, 'hlx'); // TODO !!
+    sinon.assert.calledWith(mockPublish.withFastlyAuth, 'secret-key');
+    sinon.assert.calledWith(mockPublish.withCustomVCLs, []);
+    sinon.assert.calledWith(mockPublish.withDispatchVersion, undefined);
+    sinon.assert.calledOnce(mockPublish.run);
+  });
+
   it('hlx publish implicit bot config with github token', () => {
     new CLI()
       .withCommandExecutor('publish', mockPublish)
@@ -105,6 +125,23 @@ describe('hlx publish', () => {
         '--wsk-namespace', 'hlx',
         '--fastly-auth', 'secret-key',
         '--fastly-namespace', 'hlx',
+        '--github-token', 'foobar',
+      ]);
+
+    sinon.assert.calledWith(mockPublish.withUpdateBotConfig, true);
+    sinon.assert.calledWith(mockPublish.withGithubToken, 'foobar');
+    sinon.assert.calledWith(mockPublish.withConfigPurgeAPI, 'https://app.project-helix.io/config/purge');
+    sinon.assert.calledOnce(mockPublish.run);
+  });
+
+  it('hlx publish implicit bot config with github token with serviceid', () => {
+    new CLI()
+      .withCommandExecutor('publish', mockPublish)
+      .run(['publish',
+        '--wsk-auth', 'secret-key',
+        '--wsk-namespace', 'hlx',
+        '--fastly-auth', 'secret-key',
+        '--fastly-serviceid', 'hlx',
         '--github-token', 'foobar',
       ]);
 
@@ -132,6 +169,24 @@ describe('hlx publish', () => {
     assert.fail('publish w/o github token should fail.');
   });
 
+  it('hlx publish requires github token for update config with serviceid', (done) => {
+    new CLI()
+      .withCommandExecutor('publish', mockPublish)
+      .onFail((err) => {
+        assert.ok(err.indexOf('required'));
+        done();
+      })
+      .run(['publish',
+        '--wsk-auth', 'secret-key',
+        '--wsk-namespace', 'hlx',
+        '--fastly-auth', 'secret-key',
+        '--fastly-serviceid', 'hlx',
+        '--update-bot-config',
+      ]);
+
+    assert.fail('publish w/o github token should fail.');
+  });
+
   it('hlx publish handles dispatch-version', () => {
     new CLI()
       .withCommandExecutor('publish', mockPublish)
@@ -140,6 +195,20 @@ describe('hlx publish', () => {
         '--wsk-namespace', 'hlx',
         '--fastly-auth', 'secret-key',
         '--fastly-namespace', 'hlx',
+        '--dispatch-version', 'ci1',
+      ]);
+
+    sinon.assert.calledWith(mockPublish.withDispatchVersion, 'ci1');
+  });
+
+  it('hlx publish handles dispatch-version with serviceid', () => {
+    new CLI()
+      .withCommandExecutor('publish', mockPublish)
+      .run(['publish',
+        '--wsk-auth', 'secret-key',
+        '--wsk-namespace', 'hlx',
+        '--fastly-auth', 'secret-key',
+        '--fastly-serviceid', 'hlx',
         '--dispatch-version', 'ci1',
       ]);
 


### PR DESCRIPTION
Rename fastly-namespace to fastly-serviceid, but keep compatibility with old name

"fix #1112"

Please ensure your pull request adheres to the following guidelines:
https://github.com/adobe/helix-cli/issues/1112## Related Issues