### PR TITLE
fix(publish): clear GITHUB_TOKEN from edge dictionary if given

### DIFF
--- a/src/remotepublish.cmd.js
+++ b/src/remotepublish.cmd.js
@@ -333,10 +333,8 @@ ${e}`);
       const namespace = this._fastly.writeDictItem(this._version, 'secrets', 'OPENWHISK_NAMESPACE', this._wsk_namespace);
       jobs.push(namespace);
     }
-    if (this._githubToken) {
-      const token = this._fastly.writeDictItem(this._version, 'secrets', 'GITHUB_TOKEN', this._githubToken);
-      jobs.push(token);
-    }
+    const token = this._fastly.writeDictItem(this._version, 'secrets', 'GITHUB_TOKEN', this._githubToken);
+    jobs.push(token);
     const debugKey = this._fastly.writeDictItem(this._version, 'secrets', 'DEBUG_KEY', this._debug_key || this._fastly_namespace);
     jobs.push(debugKey);
     return Promise.all(jobs).then(() => {

--- a/test/testRemotePublishCmd.dryrun.js
+++ b/test/testRemotePublishCmd.dryrun.js
@@ -58,7 +58,7 @@ describe('hlx publish --remote --dry-run (default)', () => {
       .withDryRun(true);
     await remote.run();
 
-    sinon.assert.calledThrice(writeDictItem);
+    sinon.assert.callCount(writeDictItem, 4);
     sinon.assert.notCalled(purgeAll);
   });
 });

--- a/test/testRemotePublishCmd.failpurge.js
+++ b/test/testRemotePublishCmd.failpurge.js
@@ -70,7 +70,7 @@ describe('hlx publish --remote (fail purge)', () => {
       if (e instanceof AssertionError) {
         assert.fail(e);
       }
-      sinon.assert.calledThrice(writeDictItem);
+      sinon.assert.callCount(writeDictItem, 4);
     }
   });
 

--- a/test/testRemotePublishCmd.js
+++ b/test/testRemotePublishCmd.js
@@ -67,7 +67,7 @@ describe('hlx publish --remote (default)', () => {
       .withDryRun(false);
     await remote.run();
 
-    sinon.assert.calledThrice(writeDictItem);
+    sinon.assert.callCount(writeDictItem, 4);
     sinon.assert.calledOnce(softPurgeKey);
 
     scope.done();


### PR DESCRIPTION
fixes #1162

**Note**: 
`fastly.writeDictItem()` will remove the edge dictionary entry, if the value is `undefined`.