### PR TITLE
fix(up): default to --local-repo=.

### DIFF
--- a/src/up.js
+++ b/src/up.js
@@ -59,13 +59,11 @@ module.exports = function up() {
           describe: 'Emulates a GitHub repository for the specified local git repository.',
           type: 'string',
           array: true,
+          default: '.',
         })
         // allow for comma separated values
         .coerce('localRepo', (value) => value.reduce((acc, curr) => {
-          if (curr === false) {
-            // --no-local-repo specified: add a dummy entry
-            acc.push(null);
-          } else {
+          if (curr) {
             acc.push(...curr.split(/\s*,\s*/));
           }
           return acc;
@@ -98,23 +96,13 @@ module.exports = function up() {
         executor = new UpCommand(makeLogger(argv));
       }
 
-      const { localRepo } = argv;
-      if (Array.isArray(localRepo)) {
-        if (!localRepo.length) {
-          // --local-repo option has been specified without value: use ['.'] as default
-          localRepo.push('.');
-        } else if (localRepo.length === 1 && localRepo[0] === null) {
-          // --no-local-repo option has been specified: remove dummy entry
-          localRepo.pop();
-        }
-      }
       await executor
         .withTargetDir(argv.target)
         .withFiles(argv.files)
         .withOverrideHost(argv.host)
         .withSaveConfig(argv.saveConfig)
         .withHttpPort(argv.port)
-        .withLocalRepo(localRepo)
+        .withLocalRepo(argv.localRepo)
         .withDevDefault(argv.devDefault)
         .withGithubToken(argv.githubToken)
         // only open browser window when executable is `hlx`

--- a/test/testUpCli.js
+++ b/test/testUpCli.js
@@ -53,6 +53,7 @@ describe('hlx up', () => {
     sinon.assert.calledWith(mockUp.withTargetDir, '.hlx/build');
     sinon.assert.calledWith(mockUp.withFiles, ['src/**/*.htl', 'src/**/*.js', 'src/**/*.jsx', 'cgi-bin/**/*.js']);
     sinon.assert.calledWith(mockUp.withOverrideHost, undefined);
+    sinon.assert.calledWith(mockUp.withLocalRepo, ['.']);
     sinon.assert.calledOnce(mockUp.run);
   });
 
@@ -176,7 +177,7 @@ describe('hlx up', () => {
     sinon.assert.calledOnce(mockUp.run);
   });
 
-  it('hlx up with "--local-repo <repo>" works', () => {
+  it('hlx up with "--local-repo foo" works', () => {
     new CLI()
       .withCommandExecutor('up', mockUp)
       .run(['up', '--local-repo', 'foo']);
@@ -231,13 +232,5 @@ describe('hlx up', () => {
         '--dev-default', 'HTTP_TIMEOUT', 2000,
         '--dev-default', 'HTTP_PIMEOUT', 2000, 'HTTP_QIMEOUT']);
     assert.fail('hlx up should fail when called with an uneven number of arguments');
-  });
-
-  it('hlx up can specify 1 local repo', () => {
-    new CLI()
-      .withCommandExecutor('up', mockUp)
-      .run(['up', '--local-repo', 'foo']);
-    sinon.assert.calledWith(mockUp.withLocalRepo, ['foo']);
-    sinon.assert.calledOnce(mockUp.run);
   });
 });


### PR DESCRIPTION
fixes #913

reverts to the original idea:

in `up.js`
- If no `--local-repo` is specified, yargs will default to `.`, since it's the default in the options.
- if only `--local-repo` (with not argument) is specified, yargs will default to `.`, since it's the default in the options. 
- if `--no-local-repo` is specified, yargs will use `false` as value, which is filtered in `coerce`
- any other string is coerced and split accordingly. eg:
   ```
   $ hlx up --local-repo=a,b --local-repo=d,e --local-repo
   [ 'a', 'b', 'd', 'e', '.' ]
   ```

in `up.cmd.js`
- if no local repo is specified, the simulator will automatically use the `cwd`.
- if a local repo has no `.git` directory, an error is thrown. the simulator requires a git repository.
- if a local repo has no origin, the entry is ignored. a warning is issued, if it's not `.`. 
