### PR TITLE
fix(publish): use correct default version (v3) for publish API

### DIFF
--- a/src/publish.js
+++ b/src/publish.js
@@ -41,7 +41,7 @@ module.exports = function strain() {
           alias: 'apiPublish',
           describe: 'API URL for helix-publish service.',
           type: 'string',
-          default: 'https://adobeioruntime.net/api/v1/web/helix/helix-services/publish@v2',
+          default: 'https://adobeioruntime.net/api/v1/web/helix/helix-services/publish@v3',
         })
         .option('api-config-purge', {
           alias: 'apiConfigPurge',


### PR DESCRIPTION
This is an addendum to #1254 which also changes the default for the CLI, so that the changes become active for most users

see #1254