### PR TITLE
feat(cli): dev-defaults can be set with env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ hlx deploy \
   --fastly-namespace <serviceid>
 ```
 
-As always, you can keep all parameters in `HLX_CIRCLECI_AUTH`, `HLX_WSK_AUTH`, and `HLX_FASTLY_AUTH` environment variables if you don't want them in your `.bash_history`.
+As always, you can keep all parameters in `HLX_CIRCLECI_AUTH`, `HLX_WSK_AUTH`, `HLX_DEV_DEFAULT` and `HLX_FASTLY_AUTH` environment variables if you don't want them in your `.bash_history`.
 
 ### One-Shot Deployment
 
@@ -283,6 +283,10 @@ action parameters as needed. For example, to configure request timeouts:
 ```
 $ hlx up --dev-default HTTP_TIMEOUT 2000
 ```
+
+Developers can pass additional action parameters by setting the
+`HLX_DEV_DEFAULT` environment variable. This must fulfill JSON string formatting; 
+i.e `$HLX_DEV_DEFAULT='{"KEY1":5000, "KEY2":"VALUE2"}'`
 
 For a list of known parameters, see [the Helix Pipeline Configuration Parameters documentation](https://github.com/adobe/helix-pipeline/blob/master/docs/secrets.schema.md#secrets-properties)
 

--- a/src/yargs-params.js
+++ b/src/yargs-params.js
@@ -29,6 +29,16 @@ module.exports = function commonArgs(yargs, options) {
           }
           return p;
         }, {});
+      } else if (length === 1 && typeof argv[0] === 'string' && argv[0][0] === '{') {
+        // This indicates environment variable has been set
+        try {
+          return JSON.parse(argv);
+        } catch (e) {
+          throw new Error(
+            `HLX_DEV_DEFAULT env variable is not in proper JSON format, i.e:
+             HLX_DEV_DEFAULT='{"KEY1":5000, "KEY2":"VALUE2"}'`,
+          );
+        }
       } else if (length) {
         throw new Error(`${options.name} needs an even number of parameters, think key-value pairs`);
       }

--- a/test/fixtures/all.env
+++ b/test/fixtures/all.env
@@ -18,6 +18,7 @@ HLX_OPEN = false
 HLX_PORT = 1234
 HLX_LOCAL_REPO = ., ../foo-content, ../bar-content
 #HLX_SAVE_CONFIG <forbidden use through env>
+HLX_DEV_DEFAULT='{"SECRET1": "VALUE1", "SECRET2": 5000}'
 
 # package
 HLX_FORCE = true

--- a/test/testUpCli.js
+++ b/test/testUpCli.js
@@ -240,4 +240,28 @@ describe('hlx up', () => {
         '--dev-default', 'HTTP_PIMEOUT', 2000, 'HTTP_QIMEOUT']);
     assert.fail('hlx up should fail when called with an uneven number of arguments');
   });
+
+  it('hlx up fails with bad JSON string formatting', () => {
+    let failed = false;
+    new CLI()
+      .withCommandExecutor('up', mockUp)
+      .onFail(() => {
+        failed = true;
+      })
+      .run(['up', '--dev-default', '{NoQuotes:Value, "quotes":5000}']);
+
+    assert.equal(failed, true);
+  });
+
+  it('hlx up passes with good JSON string formatting', () => {
+    let failed = false;
+    new CLI()
+      .withCommandExecutor('up', mockUp)
+      .onFail(() => {
+        failed = true;
+      })
+      .run(['up', '--dev-default', '\'{"KEY1":5000, "KEY2":"VALUE2"}\'']);
+
+    assert.equal(failed, false);
+  });
 });

--- a/test/testUpCli.js
+++ b/test/testUpCli.js
@@ -75,6 +75,7 @@ describe('hlx up', () => {
     sinon.assert.calledWith(mockUp.withHttpPort, 1234);
     sinon.assert.calledWith(mockUp.withLocalRepo, ['.', '../foo-content', '../bar-content']);
     sinon.assert.calledOnce(mockUp.run);
+    sinon.assert.calledWith(mockUp.withDevDefault, { SECRET1: 'VALUE1', SECRET2: 5000 });
   });
 
   it('hlx up fails with non env extra argument', () => {


### PR DESCRIPTION
developers can now provide extra action params that persist dev sessions using $HLX_DEV_DEFAULT env var

"fix #1266"

## Related Issues
https://github.com/adobe/helix-cli/issues/1266

Thanks for contributing!
