### PR TITLE
chore(test): record requests to helix-markup.yaml

### DIFF
--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-async_html_1336282281/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-async_html_1336282281/script-can-be-executed_530277162/recording.har
@@ -292,6 +292,149 @@
           "ssl": -1,
           "wait": 24
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:18 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20755-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127299.873519,VS0,VE1"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "2e4d790fd694d97a80d21948e4ae214d7c93aea5"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:18 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "1"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:18.780Z",
+        "time": 99,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 99
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-asynchelpx_html_1543695720/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-asynchelpx_html_1543695720/script-can-be-executed_530277162/recording.har
@@ -452,6 +452,149 @@
           "ssl": -1,
           "wait": 30
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:17 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20721-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127298.837346,VS0,VE1"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "e6df732d9a528810c0e0918d65e1ba18e0083004"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:17 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "0"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:17.745Z",
+        "time": 105,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 105
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-helpx_html_56175874/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-helpx_html_56175874/script-can-be-executed_530277162/recording.har
@@ -452,6 +452,149 @@
           "ssl": -1,
           "wait": 28
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:18 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20743-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127298.194590,VS0,VE1"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "3214d741bab87d04e7204a2b4817dfb578e4cfdb"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:18 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "1"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:18.107Z",
+        "time": 96,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 96
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-html_1194330692/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-html_1194330692/script-can-be-executed_530277162/recording.har
@@ -312,6 +312,149 @@
           "ssl": -1,
           "wait": 257
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:17 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20723-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127297.722129,VS0,VE680"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "053b5932fca33d5e9301929425a3947005353206"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:17 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "0"
+            }
+          ],
+          "headersSize": 718,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:16.653Z",
+        "time": 796,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 796
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-logger_html_1506903279/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-logger_html_1506903279/script-can-be-executed_530277162/recording.har
@@ -292,6 +292,149 @@
           "ssl": -1,
           "wait": 25
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:18 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20733-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127299.573474,VS0,VE0"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "72a637de4912d75f0f294fcbfa7b71775a1b2a52"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:18 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "1"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:18.481Z",
+        "time": 99,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 99
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-promise_html_2549031294/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-promise_html_2549031294/script-can-be-executed_530277162/recording.har
@@ -292,6 +292,149 @@
           "ssl": -1,
           "wait": 24
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:19 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20726-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127300.936498,VS0,VE1"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "d329ef5947590ddb8f9a5f91eb66474faedd85ef"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:19 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "3"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:19.852Z",
+        "time": 90,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 90
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-require_html_3192821112/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-require_html_3192821112/script-can-be-executed_530277162/recording.har
@@ -292,6 +292,149 @@
           "ssl": -1,
           "wait": 23
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:20 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20727-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127301.690150,VS0,VE1"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "02c4ed744224c5d11d3db334629ba6a7223051d6"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:20 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "3"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:20.624Z",
+        "time": 71,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 71
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-require_noext_html_2725768335/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-require_noext_html_2725768335/script-can-be-executed_530277162/recording.har
@@ -292,6 +292,149 @@
           "ssl": -1,
           "wait": 24
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:20 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20764-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127301.974552,VS0,VE1"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "0f6601dc63b5339c69109aa2ae3d1ef283b05331"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:20 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "4"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:20.894Z",
+        "time": 85,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 85
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-return_async_html_40026840/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-return_async_html_40026840/script-can-be-executed_530277162/recording.har
@@ -292,6 +292,149 @@
           "ssl": -1,
           "wait": 24
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:19 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20768-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127299.283236,VS0,VE0"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "d876bf10361122234c84bc74995d8d0d3cd6e513"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:19 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "2"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:19.205Z",
+        "time": 86,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 86
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-return_promise_html_1087596227/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-return_promise_html_1087596227/script-can-be-executed_530277162/recording.har
@@ -292,6 +292,149 @@
           "ssl": -1,
           "wait": 24
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:20 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20724-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127300.314714,VS0,VE1"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "2b58fe97665ec9a0c8a19017e00308badd4c6379"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:20 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "3"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:20.233Z",
+        "time": 89,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 89
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-return_simple_html_3798695710/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-return_simple_html_3798695710/script-can-be-executed_530277162/recording.har
@@ -292,6 +292,149 @@
           "ssl": -1,
           "wait": 26
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:21 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20752-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127302.525013,VS0,VE1"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "5cefed45ef57ed46cf0ffb7851cb17f5e124fc56"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:21 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "4"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:21.439Z",
+        "time": 91,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 91
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-simple_html_1612831361/script-can-be-executed_530277162/recording.har
+++ b/test/fixtures/recordings/Generated-Action-Tests_4194615817/Testing-simple_html_1612831361/script-can-be-executed_530277162/recording.har
@@ -292,6 +292,149 @@
           "ssl": -1,
           "wait": 25
         }
+      },
+      {
+        "_id": "7bf89496031764ea3c55418ec3dddef4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "9CBC:6F8B:B1DD8:E11DE:5E7B1F7F"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:08:21 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20748-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 1"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585127301.234008,VS0,VE1"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "05315c7e7d3c4a3cbf00a9dbf9149ba3afce6b63"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:13:21 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "4"
+            }
+          ],
+          "headersSize": 715,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:08:21.163Z",
+        "time": 77,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 77
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Integration-test-for-up-command_3614339512/up-command-delivers-correct-response-from-private-repo-_1570021791/recording.har
+++ b/test/fixtures/recordings/Integration-test-for-up-command_3614339512/up-command-delivers-correct-response-from-private-repo-_1570021791/recording.har
@@ -153,6 +153,153 @@
           "ssl": -1,
           "wait": 216
         }
+      },
+      {
+        "_id": "14b0bf8d9cb2f8cae7e028f88b80a2db",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "accept",
+              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+            },
+            {
+              "name": "authorization",
+              "value": "token 1234"
+            },
+            {
+              "name": "host",
+              "value": "raw.githubusercontent.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://raw.githubusercontent.com/Adobe-Marketing-Cloud/reactor-user-docs/master/helix-markup.yaml"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 15,
+            "text": "404: Not Found\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/6.0), 1.1 varnish"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "6D46:6491:8B055:A338E:5E7B1E16"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 25 Mar 2020 09:02:15 GMT"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-cdg20741-CDG"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1585126936.546874,VS0,VE114"
+            },
+            {
+              "name": "vary",
+              "value": "Authorization,Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-fastly-request-id",
+              "value": "0e0eb348ad72ac57afc99eb11142ec413b2a47fd"
+            },
+            {
+              "name": "expires",
+              "value": "Wed, 25 Mar 2020 09:07:15 GMT"
+            },
+            {
+              "name": "source-age",
+              "value": "0"
+            }
+          ],
+          "headersSize": 718,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2020-03-25T09:02:15.399Z",
+        "time": 251,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 251
+        }
       }
     ],
     "pages": [],


### PR DESCRIPTION
PR for #1353 

The tests are still failing but the failure is only now due to error covered by https://github.com/adobe/helix-pipeline/pull/644.
