### PR TITLE
test(up-cmd): adjust tests for new helix pipeline version

### DIFF
--- a/test/specs/json_response.json
+++ b/test/specs/json_response.json
@@ -13,8 +13,8 @@
             "nb-blockquote-1",
             "nb-delete-1",
             "nb-heading-1",
-            "is-text-html-blockquote",
-            "is-text-html",
+            "is-text-blockquote-delete",
+            "is-text-blockquote",
             "is-text"
         ]
     },


### PR DESCRIPTION
With the new pipeline changing how we order the meta types for better consistency, we need to update the cli's up command tests to match the new order

fix adobe/helix-pipeline#issues/669