### PR TITLE
fix(deploy): remove unused hlx--static

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -23,7 +23,7 @@ For dynamic requests, it invokes the adobeioruntime action, passing along conten
 and resource information. Once it retrieves the response it will cache and deliver it back to the
 client.
 
-Requests to static resources are proxied through a single global `hlx--static`
+Requests to static resources are proxied through a single global `helix-services/static@v1`
 action that handles requests to all static resources.
 
 

--- a/src/package.cmd.js
+++ b/src/package.cmd.js
@@ -233,7 +233,7 @@ class PackageCommand extends AbstractCommand {
         script.name = path.basename(script.main, '.js');
         script.bundleName = `${script.name}.bundle.js`;
         script.bundlePath = path.resolve(script.buildDir, script.bundleName);
-        script.dirname = script.isStatic ? '' : path.dirname(script.main);
+        script.dirname = path.dirname(script.main);
         script.archiveName = `${script.name}.zip`;
         script.zipFile = path.resolve(script.buildDir, script.archiveName);
         /* eslint-enable no-param-reassign */

--- a/test/testDeployCmd.js
+++ b/test/testDeployCmd.js
@@ -481,9 +481,6 @@ describe('hlx deploy (Integration)', () => {
     this.polly.server.put('https://adobeioruntime.net/api/v1/namespaces/hlx/packages/helix-services?overwrite=true').intercept((req, res) => {
       res.sendStatus(201);
     });
-    this.polly.server.put(`https://adobeioruntime.net/api/v1/namespaces/hlx/actions/${ref}/hlx--static?overwrite=true`).intercept((req, res) => {
-      res.sendStatus(201);
-    });
 
     const cmd = await new DeployCommand(logger)
       .withDirectory(testRoot)
@@ -529,7 +526,7 @@ describe('hlx deploy (Integration)', () => {
     assert.equal(newCfg.strains.get('dev').package, `hlx/${ref}`);
   });
 
-  it.only('Deploy sets action limits', async function test() {
+  it('Deploy sets action limits', async function test() {
     this.timeout(60000);
 
     await fs.copy(TEST_DIR, testRoot);
@@ -559,9 +556,6 @@ describe('hlx deploy (Integration)', () => {
         console.error(e);
         res.sendStatus(500);
       }
-    });
-    this.polly.server.put(`https://adobeioruntime.net/api/v1/namespaces/hlx/actions/${ref}/hlx--static?overwrite=true`).intercept((req, res) => {
-      res.sendStatus(201);
     });
 
     await new DeployCommand(logger)
@@ -649,9 +643,6 @@ describe('hlx deploy (Integration)', () => {
     this.polly.server.put('https://adobeioruntime.net/api/v1/namespaces/hlx/packages/helix-services?overwrite=true').intercept((req, res) => {
       res.sendStatus(201);
     });
-    this.polly.server.put(`https://adobeioruntime.net/api/v1/namespaces/hlx/actions/${ref}/hlx--static?overwrite=true`).intercept((req, res) => {
-      res.sendStatus(201);
-    });
 
     const cmd = await new DeployCommand(logger)
       .withDirectory(testRoot)
@@ -713,13 +704,10 @@ describe('hlx deploy (Integration)', () => {
       res.sendStatus(201);
     });
     this.polly.server.put(`https://adobeioruntime.net/api/v1/namespaces/hlx/actions/${ref}/html?overwrite=true`).intercept((req, res) => {
-      res.sendStatus(201);
+      res.sendStatus(500);
     });
     this.polly.server.put('https://adobeioruntime.net/api/v1/namespaces/hlx/packages/helix-services?overwrite=true').intercept((req, res) => {
       res.sendStatus(201);
-    });
-    this.polly.server.get('https://adobeioruntime.net/api/v1/web/helix/helix-services/static@latest').intercept((req, res) => {
-      res.sendStatus(500);
     });
 
     try {


### PR DESCRIPTION
removing `hlx--static` action because dispatch now used `helix-services/static@v1`

see https://github.com/adobe/helix-dispatch/issues/319
