### PR TITLE
fix(build): add option to generate universal action

### DIFF
--- a/src/build.cmd.js
+++ b/src/build.cmd.js
@@ -29,6 +29,7 @@ class BuildCommand extends AbstractCommand {
     this._helixPages = null;
     this._modulePaths = [];
     this._requiredModules = [{ name: HLX_PIPELINE_MOD, descriptor: `${HLX_PIPELINE_MOD}@latest` }];
+    this._universal = false;
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -81,6 +82,11 @@ class BuildCommand extends AbstractCommand {
     return this;
   }
 
+  withUniversal(value) {
+    this._universal = value;
+    return this;
+  }
+
   /**
    * @override
    */
@@ -109,6 +115,7 @@ class BuildCommand extends AbstractCommand {
       .withLogger(this.log)
       .withFiles(this._files)
       .withRequiredModules(this._requiredModules)
+      .withUniversal(this._universal)
       .withShowReport(true);
 
     if (await this.helixPages.isPagesProject()) {

--- a/src/build.js
+++ b/src/build.js
@@ -40,6 +40,7 @@ module.exports = function build() {
         .withTargetDir(argv.target)
         .withFiles(argv.files)
         .withCustomPipeline(argv.customPipeline)
+        .withUniversal(argv.universal)
         .run();
     },
   };

--- a/src/builder/Builder.js
+++ b/src/builder/Builder.js
@@ -26,6 +26,7 @@ const CGI_PAT = `${path.sep}cgi-bin${path.sep}`;
 
 const RUNTIME_TEMPLATE = path.resolve(__dirname, 'RuntimeTemplate.js');
 const ACTION_TEMPLATE = path.resolve(__dirname, 'ActionTemplate.js');
+const UNIVERSAL_TEMPLATE = path.resolve(__dirname, 'UniversalTemplate.js');
 const DEFAULT_PIPELINE = '@adobe/helix-pipeline/src/defaults/default.js';
 
 /**
@@ -68,6 +69,7 @@ class Builder {
     this._buildDir = '.hlx/build';
     this._showReport = false;
     this._modulePaths = [];
+    this._universsal = false;
   }
 
   withDirectory(d) {
@@ -107,6 +109,11 @@ class Builder {
 
   withRequiredModules(value) {
     this._required = value;
+    return this;
+  }
+
+  withUniversal(value) {
+    this._universal = value;
     return this;
   }
 
@@ -194,7 +201,9 @@ class Builder {
 
   // eslint-disable-next-line class-methods-use-this
   async generateScript(info) {
-    let body = await fse.readFile(ACTION_TEMPLATE, 'utf-8');
+    let body = this._universal
+      ? await fse.readFile(UNIVERSAL_TEMPLATE, 'utf-8')
+      : await fse.readFile(ACTION_TEMPLATE, 'utf-8');
     body = body.replace(/'MOD_PIPE'/, JSON.stringify(info.pipe));
     body = body.replace(/'MOD_PRE'/, JSON.stringify(info.pre));
     body = body.replace(/'MOD_SCRIPT'/, JSON.stringify(`./${path.relative(info.buildDir, info.scriptFile)}`));

--- a/src/builder/UniversalTemplate.js
+++ b/src/builder/UniversalTemplate.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable */
+const { UniversalAction } = require('@adobe/helix-pipeline');
+const { pipe } = require('MOD_PIPE');
+const { pre, before, after, replace } = require('MOD_PRE');
+const script = require('MOD_SCRIPT');
+
+// todo: move to helix-pipeline
+const CONTEXT_PROPS = ['error', 'request', 'content', 'response'];
+const CONTENT_PROPS = ['sources', 'body', 'mdast', 'sections', 'document', 'htast', 'json', 'xml', 'meta', 'title', 'intro', 'image'];
+const REQUEST_PROPS = ['url', 'path', 'pathInfo', 'rootPath', 'selector', 'extension', 'method', 'headers', 'params'];
+const RESPONSE_PROPS = ['status', 'body', 'hast', 'headers', 'document'];
+
+const filterObject = (obj, allowedProperties) => {
+  if (!obj) {
+    return;
+  }
+  Object.keys(obj).forEach((key) => {
+    if (allowedProperties.indexOf(key) < 0) {
+      delete obj[key];
+    }
+  });
+};
+
+const sanitizeContext = (context) => {
+  filterObject(context, CONTEXT_PROPS);
+  filterObject(context.content, CONTENT_PROPS);
+  filterObject(context.request, REQUEST_PROPS);
+  filterObject(context.response, RESPONSE_PROPS);
+};
+
+// this gets called by the universal adapter
+async function main(req, ctx) {
+  // this is the once function that will be installed in the pipeline
+  async function once(context, action) {
+    // calls the pre function ...
+    const ret = await Promise.resolve(pre(context, action));
+    // ... and then the script's main.
+    const res = await Promise.resolve(script.main(ret || context, action));
+    if (!context.response) {
+      context.response = {};
+    }
+    if (typeof res === 'object') {
+      // check for response from direct script
+      if (res.response) {
+        context.response = res.response;
+      } else if (res.type) {
+        context.response.hast = res;
+      } else {
+        context.response.document = res;
+      }
+    } else {
+      context.response.body = String(res);
+    }
+    sanitizeContext(context);
+    return context;
+  }
+
+  if (before) {
+    once.before = before;
+  }
+  if (after) {
+    once.after = after;
+  }
+  if (replace) {
+    once.replace = replace;
+  }
+  return UniversalAction.runPipeline(once, pipe, req, ctx);
+}
+
+module.exports.main = main;

--- a/src/yargs-build.js
+++ b/src/yargs-build.js
@@ -23,6 +23,11 @@ module.exports = function commonArgs(yargs) {
       type: 'string',
       default: '',
     })
+    .option('universal', {
+      describe: 'Generate an universal bundle instead of an on openwhisk action.',
+      type: 'boolean',
+      default: false,
+    })
     .positional('files', {
       describe: 'The template files to compile',
       default: ['src/**/*.htl', 'src/**/*.js', 'src/**/*.jsx', 'cgi-bin/**/*.js'],

--- a/test/testBuildCli.js
+++ b/test/testBuildCli.js
@@ -32,6 +32,7 @@ describe('hlx build', () => {
     mockBuild.withTargetDir.returnsThis();
     mockBuild.withFiles.returnsThis();
     mockBuild.withCustomPipeline.returnsThis();
+    mockBuild.withUniversal.returnsThis();
     mockBuild.run.returnsThis();
   });
 
@@ -49,6 +50,7 @@ describe('hlx build', () => {
       .run(['build']);
     sinon.assert.calledWith(mockBuild.withTargetDir, '.hlx/build');
     sinon.assert.calledWith(mockBuild.withFiles, ['src/**/*.htl', 'src/**/*.js', 'src/**/*.jsx', 'cgi-bin/**/*.js']);
+    sinon.assert.calledWith(mockBuild.withUniversal, false);
     sinon.assert.calledOnce(mockBuild.run);
   });
 
@@ -67,6 +69,14 @@ describe('hlx build', () => {
       .withCommandExecutor('build', mockBuild)
       .run(['build', '--target', 'tmp/build']);
     sinon.assert.calledWith(mockBuild.withTargetDir, 'tmp/build');
+    sinon.assert.calledOnce(mockBuild.run);
+  });
+
+  it('hlx build can set universal', () => {
+    new CLI()
+      .withCommandExecutor('build', mockBuild)
+      .run(['build', '--universal']);
+    sinon.assert.calledWith(mockBuild.withUniversal, true);
     sinon.assert.calledOnce(mockBuild.run);
   });
 

--- a/test/testBuildCmd.js
+++ b/test/testBuildCmd.js
@@ -62,6 +62,19 @@ describe('Integration test for build', function suite() {
     assert.ok(htmlJs.indexOf('sourceMappingURL=html.script.js.map') >= 0);
   });
 
+  it('build command can use universal template', async () => {
+    await new BuildCommand()
+      .withFiles(['src/**/*.htl', 'src/**/*.js'])
+      .withUniversal(true)
+      .withDirectory(path.resolve(__dirname, 'integration'))
+      .withTargetDir(buildDir)
+      .withRequiredModules([])
+      .run();
+
+    const html = await fs.readFile(path.resolve(buildDir, 'src', 'html.js'), 'utf-8');
+    assert.ok(html.indexOf('UniversalAction') >= 0);
+  });
+
   it('build provides a default pipeline', async () => {
     await new BuildCommand()
       .withFiles(['src/**/*.htl', 'src/**/*.js'])


### PR DESCRIPTION
fixes #1595

The new `--universal` flag will use the `UniversalAction` from the pipeline, suitable to use for deployment via helix-deploy.
Adding the entire deploy logic for all targets is overkill. IMO, splitting this into build and deployment via `helix-deploy` is good for now.