### PR TITLE
test(integration): fix test recordings for embeds on universal runtime

### DIFF
--- a/test/fixtures/recordings/Integration-test-for-up-command_3614339512/up-command-delivers-correct-response-_668345128/recording.har
+++ b/test/fixtures/recordings/Integration-test-for-up-command_3614339512/up-command-delivers-correct-response-_668345128/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "ab519cac78c1bc2a4eec343a2b7772a6",
+        "_id": "aca3d8738b2ea1d84cbb5dd510f73249",
         "_order": 0,
         "cache": {},
         "request": {
@@ -16,20 +16,8 @@
           "cookies": [],
           "headers": [
             {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
               "name": "accept",
               "value": "text/html, application/xhtml+xml, application/xml"
-            },
-            {
-              "name": "user-agent",
-              "value": "helix-fetch"
-            },
-            {
-              "name": "accept-encoding",
-              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
             },
             {
               "name": "x-esi",
@@ -37,10 +25,18 @@
             },
             {
               "name": "host",
-              "value": "adobeioruntime.net"
+              "value": "helix-pages.anywhere.run"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch/2.2.0"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,br"
             }
           ],
-          "headersSize": 349,
+          "headersSize": 308,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -49,98 +45,98 @@
               "value": "with params"
             }
           ],
-          "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/embed@v1/https://embeds.project-helix.io/jekyll_embed?params=with%20params"
+          "url": "https://helix-pages.anywhere.run/helix-services/embed@v1/https://embeds.project-helix.io/jekyll_embed?params=with%20params"
         },
         "response": {
-          "bodySize": 272,
+          "bodySize": 293,
           "content": {
-            "mimeType": "text/html; charset=UTF-8",
-            "size": 272,
-            "text": "<div class=\"embed  embed-has-url embed-project-helix embed-project-helix-embeds embed-has-title\">\n  <a href=\"https://embeds.project-helix.io/jekyll_embed?params=with+params\">\n    <span class=\"title\">Fastly error: unknown domain embeds.project-helix.io</span>\n  </a>\n</div>"
+            "mimeType": "text/html;charset=UTF-8",
+            "size": 293,
+            "text": "<div class=\"embed  embed-has-title embed-has-url embed-project-helix embed-project-helix-embeds\">\n    <span class=\"title\" style=\"display:none\">Fastly error: unknown domain embeds.project-helix.io</span>\n  <a href=\"https://embeds.project-helix.io/jekyll_embed?params=with+params\">\n  </a>\n</div>"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "access-control-allow-headers",
-              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
+              "name": "connection",
+              "value": "close"
             },
             {
-              "name": "access-control-allow-methods",
-              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+              "name": "content-length",
+              "value": "293"
             },
             {
-              "name": "access-control-allow-origin",
-              "value": "*"
+              "name": "content-type",
+              "value": "text/html;charset=UTF-8"
             },
             {
               "name": "cache-control",
               "value": "max-age=3600"
             },
             {
-              "name": "content-type",
-              "value": "text/html; charset=UTF-8"
-            },
-            {
-              "name": "date",
-              "value": "Thu, 09 Jul 2020 09:13:52 GMT"
-            },
-            {
-              "name": "perf-br-resp-out",
-              "value": "1594286032.536"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=7884000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "deny"
-            },
-            {
-              "name": "x-gw-cache",
-              "value": "MISS"
-            },
-            {
-              "name": "x-last-activation-id",
-              "value": "fc2c22878ad445afac22878ad425af73"
-            },
-            {
-              "name": "x-openwhisk-activation-id",
-              "value": "1b78eb5d91e2401db8eb5d91e2601d1e"
+              "name": "x-invocation-id",
+              "value": "78af7242-93ca-41ec-9580-018e8229707a"
             },
             {
               "name": "x-provider",
               "value": "unfurl.js"
             },
             {
-              "name": "x-request-id",
-              "value": "Uvs1jCfU2DH5PSP4K2VEcIXbORCJu3cI"
+              "name": "apigw-requestid",
+              "value": "eI9oHhzoIAMESVA="
             },
             {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
+              "name": "x-backend-url",
+              "value": "/helix-services/embed/1.11.10/https://embeds.project-helix.io/jekyll_embed?params=with%20params"
             },
             {
-              "name": "content-length",
-              "value": "272"
+              "name": "x-backend-name",
+              "value": "0trc7KZPj73TyFfFhsUyWu--F_AmazonWebServices"
             },
             {
-              "name": "connection",
-              "value": "keep-alive"
+              "name": "x-backend-health",
+              "value": "1 1 1"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 21 Apr 2021 15:21:38 GMT"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-fra19147-FRA"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1619018496.365475,VS0,VE1780"
+            },
+            {
+              "name": "x-gateway-restarts",
+              "value": "0"
             }
           ],
-          "headersSize": 758,
+          "headersSize": 626,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-09T09:13:48.949Z",
-        "time": 3642,
+        "startedDateTime": "2021-04-21T15:21:36.299Z",
+        "time": 1813,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,7 +144,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 3642
+          "wait": 1813
         }
       }
     ],

--- a/test/fixtures/recordings/Integration-test-for-up-command_3614339512/up-command-delivers-correct-response-with-live-reload-_1789795472/recording.har
+++ b/test/fixtures/recordings/Integration-test-for-up-command_3614339512/up-command-delivers-correct-response-with-live-reload-_1789795472/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "ab519cac78c1bc2a4eec343a2b7772a6",
+        "_id": "aca3d8738b2ea1d84cbb5dd510f73249",
         "_order": 0,
         "cache": {},
         "request": {
@@ -16,20 +16,8 @@
           "cookies": [],
           "headers": [
             {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
               "name": "accept",
               "value": "text/html, application/xhtml+xml, application/xml"
-            },
-            {
-              "name": "user-agent",
-              "value": "helix-fetch"
-            },
-            {
-              "name": "accept-encoding",
-              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
             },
             {
               "name": "x-esi",
@@ -37,10 +25,18 @@
             },
             {
               "name": "host",
-              "value": "adobeioruntime.net"
+              "value": "helix-pages.anywhere.run"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch/2.2.0"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,br"
             }
           ],
-          "headersSize": 349,
+          "headersSize": 308,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -49,98 +45,98 @@
               "value": "with params"
             }
           ],
-          "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/embed@v1/https://embeds.project-helix.io/jekyll_embed?params=with%20params"
+          "url": "https://helix-pages.anywhere.run/helix-services/embed@v1/https://embeds.project-helix.io/jekyll_embed?params=with%20params"
         },
         "response": {
-          "bodySize": 272,
+          "bodySize": 293,
           "content": {
-            "mimeType": "text/html; charset=UTF-8",
-            "size": 272,
-            "text": "<div class=\"embed  embed-has-url embed-project-helix embed-project-helix-embeds embed-has-title\">\n  <a href=\"https://embeds.project-helix.io/jekyll_embed?params=with+params\">\n    <span class=\"title\">Fastly error: unknown domain embeds.project-helix.io</span>\n  </a>\n</div>"
+            "mimeType": "text/html;charset=UTF-8",
+            "size": 293,
+            "text": "<div class=\"embed  embed-has-title embed-has-url embed-project-helix embed-project-helix-embeds\">\n    <span class=\"title\" style=\"display:none\">Fastly error: unknown domain embeds.project-helix.io</span>\n  <a href=\"https://embeds.project-helix.io/jekyll_embed?params=with+params\">\n  </a>\n</div>"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "access-control-allow-headers",
-              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
+              "name": "connection",
+              "value": "close"
             },
             {
-              "name": "access-control-allow-methods",
-              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+              "name": "content-length",
+              "value": "293"
             },
             {
-              "name": "access-control-allow-origin",
-              "value": "*"
+              "name": "content-type",
+              "value": "text/html;charset=UTF-8"
             },
             {
               "name": "cache-control",
               "value": "max-age=3600"
             },
             {
-              "name": "content-type",
-              "value": "text/html; charset=UTF-8"
-            },
-            {
-              "name": "date",
-              "value": "Thu, 09 Jul 2020 09:13:54 GMT"
-            },
-            {
-              "name": "perf-br-resp-out",
-              "value": "1594286034.526"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=7884000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "deny"
-            },
-            {
-              "name": "x-gw-cache",
-              "value": "HIT"
-            },
-            {
-              "name": "x-last-activation-id",
-              "value": "fc2c22878ad445afac22878ad425af73"
-            },
-            {
-              "name": "x-openwhisk-activation-id",
-              "value": "1b78eb5d91e2401db8eb5d91e2601d1e"
+              "name": "x-invocation-id",
+              "value": "ee85b9c0-468d-487b-a767-f088a4c6f7fa"
             },
             {
               "name": "x-provider",
               "value": "unfurl.js"
             },
             {
-              "name": "x-request-id",
-              "value": "Uvs1jCfU2DH5PSP4K2VEcIXbORCJu3cI"
+              "name": "apigw-requestid",
+              "value": "eI-nxhuvIAMESPA="
             },
             {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
+              "name": "x-backend-url",
+              "value": "/helix-services/embed/1.11.10/https://embeds.project-helix.io/jekyll_embed?params=with%20params"
             },
             {
-              "name": "content-length",
-              "value": "272"
+              "name": "x-backend-name",
+              "value": "0trc7KZPj73TyFfFhsUyWu--F_AmazonWebServices"
             },
             {
-              "name": "connection",
-              "value": "keep-alive"
+              "name": "x-backend-health",
+              "value": "1 1 1"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 21 Apr 2021 15:28:24 GMT"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-hhn4074-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1619018904.709846,VS0,VE728"
+            },
+            {
+              "name": "x-gateway-restarts",
+              "value": "0"
             }
           ],
-          "headersSize": 757,
+          "headersSize": 624,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-09T09:13:54.142Z",
-        "time": 438,
+        "startedDateTime": "2021-04-21T15:28:23.662Z",
+        "time": 792,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,7 +144,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 438
+          "wait": 792
         }
       }
     ],

--- a/test/fixtures/recordings/Integration-test-for-up-command_3614339512/up-command-handles-modified-sources-and-delivers-correct-response-_3100915401/recording.har
+++ b/test/fixtures/recordings/Integration-test-for-up-command_3614339512/up-command-handles-modified-sources-and-delivers-correct-response-_3100915401/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "ab519cac78c1bc2a4eec343a2b7772a6",
+        "_id": "aca3d8738b2ea1d84cbb5dd510f73249",
         "_order": 0,
         "cache": {},
         "request": {
@@ -16,20 +16,8 @@
           "cookies": [],
           "headers": [
             {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
               "name": "accept",
               "value": "text/html, application/xhtml+xml, application/xml"
-            },
-            {
-              "name": "user-agent",
-              "value": "helix-fetch"
-            },
-            {
-              "name": "accept-encoding",
-              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
             },
             {
               "name": "x-esi",
@@ -37,10 +25,18 @@
             },
             {
               "name": "host",
-              "value": "adobeioruntime.net"
+              "value": "helix-pages.anywhere.run"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch/2.2.0"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,br"
             }
           ],
-          "headersSize": 349,
+          "headersSize": 308,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -49,98 +45,98 @@
               "value": "with params"
             }
           ],
-          "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/embed@v1/https://embeds.project-helix.io/jekyll_embed?params=with%20params"
+          "url": "https://helix-pages.anywhere.run/helix-services/embed@v1/https://embeds.project-helix.io/jekyll_embed?params=with%20params"
         },
         "response": {
-          "bodySize": 272,
+          "bodySize": 293,
           "content": {
-            "mimeType": "text/html; charset=UTF-8",
-            "size": 272,
-            "text": "<div class=\"embed  embed-has-url embed-project-helix embed-project-helix-embeds embed-has-title\">\n  <a href=\"https://embeds.project-helix.io/jekyll_embed?params=with+params\">\n    <span class=\"title\">Fastly error: unknown domain embeds.project-helix.io</span>\n  </a>\n</div>"
+            "mimeType": "text/html;charset=UTF-8",
+            "size": 293,
+            "text": "<div class=\"embed  embed-has-title embed-has-url embed-project-helix embed-project-helix-embeds\">\n    <span class=\"title\" style=\"display:none\">Fastly error: unknown domain embeds.project-helix.io</span>\n  <a href=\"https://embeds.project-helix.io/jekyll_embed?params=with+params\">\n  </a>\n</div>"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "access-control-allow-headers",
-              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
+              "name": "connection",
+              "value": "close"
             },
             {
-              "name": "access-control-allow-methods",
-              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+              "name": "content-length",
+              "value": "293"
             },
             {
-              "name": "access-control-allow-origin",
-              "value": "*"
+              "name": "content-type",
+              "value": "text/html;charset=UTF-8"
             },
             {
               "name": "cache-control",
               "value": "max-age=3600"
             },
             {
-              "name": "content-type",
-              "value": "text/html; charset=UTF-8"
-            },
-            {
-              "name": "date",
-              "value": "Thu, 09 Jul 2020 09:14:05 GMT"
-            },
-            {
-              "name": "perf-br-resp-out",
-              "value": "1594286045.443"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=7884000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "deny"
-            },
-            {
-              "name": "x-gw-cache",
-              "value": "HIT"
-            },
-            {
-              "name": "x-last-activation-id",
-              "value": "fc2c22878ad445afac22878ad425af73"
-            },
-            {
-              "name": "x-openwhisk-activation-id",
-              "value": "1b78eb5d91e2401db8eb5d91e2601d1e"
+              "name": "x-invocation-id",
+              "value": "4add1f5d-d0f3-4eab-95f2-9effddaad10c"
             },
             {
               "name": "x-provider",
               "value": "unfurl.js"
             },
             {
-              "name": "x-request-id",
-              "value": "Uvs1jCfU2DH5PSP4K2VEcIXbORCJu3cI"
+              "name": "apigw-requestid",
+              "value": "eI_Mui4xIAMESjg="
             },
             {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
+              "name": "x-backend-url",
+              "value": "/helix-services/embed/1.11.10/https://embeds.project-helix.io/jekyll_embed?params=with%20params"
             },
             {
-              "name": "content-length",
-              "value": "272"
+              "name": "x-backend-name",
+              "value": "0trc7KZPj73TyFfFhsUyWu--F_AmazonWebServices"
             },
             {
-              "name": "connection",
-              "value": "keep-alive"
+              "name": "x-backend-health",
+              "value": "1 1 1"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 21 Apr 2021 15:32:21 GMT"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-fra19140-FRA"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1619019141.549948,VS0,VE1327"
+            },
+            {
+              "name": "x-gateway-restarts",
+              "value": "0"
             }
           ],
-          "headersSize": 757,
+          "headersSize": 626,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-09T09:14:05.057Z",
-        "time": 441,
+        "startedDateTime": "2021-04-21T15:32:20.500Z",
+        "time": 1440,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,7 +144,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 441
+          "wait": 1440
         }
       }
     ],

--- a/test/specs/simple_response.html
+++ b/test/specs/simple_response.html
@@ -21,10 +21,10 @@ Nothing happens here, yet.
                 <p><strong>note</strong>
                         This is a note. Who’d have noted?</p>
         </div>
-        <p></p><div class="embed  embed-has-url embed-project-helix embed-project-helix-embeds embed-has-title">
-        <a href="https://embeds.project-helix.io/jekyll_embed?params=with+params">
-                <span class="title">Fastly error: unknown domain embeds.project-helix.io</span>
-        </a>
+<p></p><div class="embed  embed-has-title embed-has-url embed-project-helix embed-project-helix-embeds">
+    <span class="title" style="display:none">Fastly error: unknown domain embeds.project-helix.io</span>
+  <a href="https://embeds.project-helix.io/jekyll_embed?params=with+params">
+  </a>
 </div><p></p>
         <script>
                 alert('hello');

--- a/test/specs/simple_response_with_livereload.html
+++ b/test/specs/simple_response_with_livereload.html
@@ -22,10 +22,10 @@ Nothing happens here, yet.
                 <p><strong>note</strong>
                         This is a note. Who’d have noted?</p>
         </div>
-        <p></p><div class="embed  embed-has-url embed-project-helix embed-project-helix-embeds embed-has-title">
-        <a href="https://embeds.project-helix.io/jekyll_embed?params=with+params">
-                <span class="title">Fastly error: unknown domain embeds.project-helix.io</span>
-        </a>
+<p></p><div class="embed  embed-has-title embed-has-url embed-project-helix embed-project-helix-embeds">
+    <span class="title" style="display:none">Fastly error: unknown domain embeds.project-helix.io</span>
+  <a href="https://embeds.project-helix.io/jekyll_embed?params=with+params">
+  </a>
 </div><p></p>
         <script>
                 alert('hello');


### PR DESCRIPTION
adobe/helix-pipeline#1056 switches the embed service URL to universal runtime. This means that some of the recordings for the integration tests need to be re-downloaded, as the URL has changed. As helix-embed has evolved in the meantime, this also means that the test output has changed a bit. There is a good chance that we will end up in a smoke test deadlock, as this PR won't pass the tests until adobe/helix-pipeline#1056 has been merged and vice versa.
