### PR TITLE
Implement kill switch

### DIFF
--- a/src/server/HelixProject.js
+++ b/src/server/HelixProject.js
@@ -26,10 +26,16 @@ export default class HelixProject {
     this._headHtml = null;
     this._indexer = null;
     this._printIndex = false;
+    this._kill = false;
   }
 
   withCwd(cwd) {
     this._cwd = cwd;
+    return this;
+  }
+
+  withKill(kill) {
+    this._kill = !!kill;
     return this;
   }
 
@@ -80,6 +86,10 @@ export default class HelixProject {
 
   get indexer() {
     return this._indexer;
+  }
+
+  get kill() {
+    return this._kill;
   }
 
   /**

--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -133,7 +133,7 @@ export default class HelixServer extends EventEmitter {
   async start() {
     const { log } = this;
     if (this._port !== 0) {
-      if (this._kill) {
+      if (this._kill && await utils.checkPortInUse(this._port)) {
         await fetch(`http://localhost:${this._port}/.kill`);
       }
       const inUse = await utils.checkPortInUse(this._port);

--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -107,6 +107,10 @@ export default class HelixServer extends EventEmitter {
 
   async setupApp() {
     const handler = asyncHandler(this.handleProxyModeRequest.bind(this));
+    this._app.get('/.kill', (req, res) => {
+      res.send('Goodbye!');
+      process.exit();
+    });
     this._app.get('*', handler);
     this._app.post('*', handler);
   }

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -54,6 +54,11 @@ export default class UpCommand extends AbstractCommand {
     return this;
   }
 
+  withKill(value) {
+    this._kill = value;
+    return this;
+  }
+
   get project() {
     return this._project;
   }
@@ -91,6 +96,7 @@ export default class UpCommand extends AbstractCommand {
       .withCwd(this.directory)
       .withLiveReload(this._liveReload)
       .withLogger(this._logger)
+      .withKill(this._kill)
       .withPrintIndex(this._printIndex);
 
     this.log.info(chalk`{yellow     __ __    ___       ___                  }`);

--- a/src/up.js
+++ b/src/up.js
@@ -51,6 +51,11 @@ export default function up() {
           type: 'int',
           default: 3000,
         })
+        .option('kill', {
+          describe: 'Kill existing Helix CLI running on the above port',
+          type: 'boolean',
+          default: true,
+        })
         .option('print-index', {
           alias: 'printIndex',
           describe: 'Prints the indexed records for the current page.',
@@ -81,6 +86,7 @@ export default function up() {
         .withLiveReload(argv.livereload)
         .withPagesUrl(argv.pagesUrl)
         .withPrintIndex(argv.printIndex)
+        .withKill(argv.kill)
         .run();
     },
   };

--- a/src/up.js
+++ b/src/up.js
@@ -51,8 +51,8 @@ export default function up() {
           type: 'int',
           default: 3000,
         })
-        .option('kill', {
-          describe: 'Kill existing Helix CLI running on the above port',
+        .option('--stop-other', {
+          describe: 'Stop other Helix CLI running on the above port',
           type: 'boolean',
           default: true,
         })
@@ -86,7 +86,7 @@ export default function up() {
         .withLiveReload(argv.livereload)
         .withPagesUrl(argv.pagesUrl)
         .withPrintIndex(argv.printIndex)
-        .withKill(argv.kill)
+        .withKill(argv.stopOther)
         .run();
     },
   };

--- a/test/server-utils.test.js
+++ b/test/server-utils.test.js
@@ -191,11 +191,11 @@ describe('Utils Test', () => {
       }
     });
 
-    it('gives an error for port not available', async () => {
+    it.only('gives an error for port not available', async () => {
       try {
         await utils.checkPortInUse(0);
       } catch (e) {
-        assert.ok(e.toString().startsWith('Error: connect EADDRNOTAVAIL 127.0.0.1 - Local (0.0.0.0:'));
+        assert.ok(e.toString().startsWith('Error: connect EADDRNOTAVAIL'));
       }
     });
   });

--- a/test/server-utils.test.js
+++ b/test/server-utils.test.js
@@ -191,7 +191,7 @@ describe('Utils Test', () => {
       }
     });
 
-    it.only('gives an error for port not available', async () => {
+    it('gives an error for port not available', async () => {
       try {
         await utils.checkPortInUse(0);
       } catch (e) {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -88,6 +88,7 @@ describe('Helix Server', () => {
       await project.start();
       await assertHttp(`http://localhost:${project.server.port}/.kill`, 200, 'expected_goodbye.txt');
     } finally {
+      assert.ok(!project.server.isStarted());
       await project.stop();
     }
   });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -77,6 +77,27 @@ describe('Helix Server', () => {
     }
   });
 
+  it('stops server on /.kill', async () => {
+    const cwd = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
+    const project = new HelixProject()
+      .withCwd(cwd)
+      .withHttpPort(0);
+    await project.init();
+    const { exit } = process;
+    try {
+      let stopped = false;
+      process.exit = function fakeexit() {
+        stopped = true;
+      };
+      await project.start();
+      await assertHttp(`http://localhost:${project.server.port}/.kill`, 200, 'expected_goodbye.txt');
+      assert.ok(stopped);
+    } finally {
+      await project.stop();
+      process.exit = exit;
+    }
+  });
+
   it('deliver 404 for static content non existing', async () => {
     const cwd = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
     const project = new HelixProject()

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -50,10 +50,11 @@ describe('Helix Server', () => {
 
       const project2 = new HelixProject()
         .withCwd(cwd)
+        .withKill(false)
         .withHttpPort(project.server.port);
       await project2.init();
       try {
-        await project.start();
+        await project2.start();
         assert.fail('server should detect port in use.');
       } catch (e) {
         assert.equal(e.message, `Port ${project.server.port} already in use by another process.`);
@@ -83,18 +84,11 @@ describe('Helix Server', () => {
       .withCwd(cwd)
       .withHttpPort(0);
     await project.init();
-    const { exit } = process;
     try {
-      let stopped = false;
-      process.exit = function fakeexit() {
-        stopped = true;
-      };
       await project.start();
       await assertHttp(`http://localhost:${project.server.port}/.kill`, 200, 'expected_goodbye.txt');
-      assert.ok(stopped);
     } finally {
       await project.stop();
-      process.exit = exit;
     }
   });
 

--- a/test/specs/expected_goodbye.txt
+++ b/test/specs/expected_goodbye.txt
@@ -1,0 +1,1 @@
+Goodbye!

--- a/test/up-cli.test.js
+++ b/test/up-cli.test.js
@@ -32,6 +32,7 @@ describe('hlx up', () => {
     mockUp.withHttpPort.returnsThis();
     mockUp.withPagesUrl.returnsThis();
     mockUp.withPrintIndex.returnsThis();
+    mockUp.withKill.returnsThis();
     mockUp.run.returnsThis();
     cli = (await new CLI().initCommands()).withCommandExecutor('up', mockUp);
   });


### PR DESCRIPTION
- feat(server): add `/.kill` switch to quickly turn the server off
- feat(cli): add `--kill` option (default: on) to kill other Helix CLI server instances on the same port

fixes #1939