### PR TITLE
chore: fix and enable Windows tests 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,9 @@ jobs:
       - checkout
       - run: choco install nodejs-lts --version=14.17.6
       - run: mkdir junit
+      - run:
+        name: Installing Dependencies
+        command: npm ci
 
       # test & get code coverage
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,8 @@ jobs:
       - run: choco install nodejs-lts --version=14.17.6
       - run: mkdir junit
       - run:
-        name: Installing Dependencies
-        command: npm ci
+          name: Installing Dependencies
+          command: npm ci
 
       # test & get code coverage
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,4 +88,4 @@ workflows:
   build:
     jobs:
     - build
-    # - build_win
+    - build_win

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -105,7 +105,7 @@ const utils = {
       const index = fileName.lastIndexOf('.');
       if (index > -1) {
         // inject qs as b64 in filename before extension
-        fileName = `${fileName.substring(0, index)}.${qs}${fileName.substring(index)}`;
+        fileName = `${fileName.substring(0, index)}.${qs.substring(1)}${fileName.substring(index)}`;
       } else {
         fileName = `${fileName}.${qs}`;
       }

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -145,7 +145,6 @@ const utils = {
    */
   async getFromCache(pathname, qs, directory, logger) {
     try {
-      console.log('WINDOWS DEBUGGING', pathname, qs, directory);
       const filePath = utils.computePathForCache(pathname, qs, directory);
       logger.debug(`Trying from cache first: ${filePath}`);
 

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -107,7 +107,7 @@ const utils = {
         // inject qs as b64 in filename before extension
         fileName = `${fileName.substring(0, index)}.${qs.substring(1)}${fileName.substring(index)}`;
       } else {
-        fileName = `${fileName}.${qs}`;
+        fileName = `${fileName}.${qs.substring(1)}`;
       }
     }
     const filePath = path.resolve(directory, fileName.substring(1));
@@ -145,6 +145,7 @@ const utils = {
    */
   async getFromCache(pathname, qs, directory, logger) {
     try {
+      console.log('WINDOWS DEBUGGING', pathname, qs, directory);
       const filePath = utils.computePathForCache(pathname, qs, directory);
       logger.debug(`Trying from cache first: ${filePath}`);
 

--- a/test/server-utils.test.js
+++ b/test/server-utils.test.js
@@ -13,6 +13,7 @@
 import assert from 'assert';
 import fse from 'fs-extra';
 import net from 'net';
+import path from 'path';
 import RequestContext from '../src/server/RequestContext.js';
 import utils from '../src/server/utils.js';
 import { createTestRoot } from './utils.js';
@@ -248,10 +249,10 @@ describe('Utils Test', () => {
 
   describe('Cache', () => {
     it('compute path for cache', () => {
-      assert.equal(utils.computePathForCache('/index.html', '', '/target/'), '/target/index.html');
-      assert.equal(utils.computePathForCache('/folder/index.html', '', '/target/'), '/target/folder/index.html');
-      assert.equal(utils.computePathForCache('/script.js', '', '/target/'), '/target/script.js');
-      assert.equal(utils.computePathForCache('/page.html', '?foo=bar&baz=qux', '/target/'), '/target/page.foo=bar&baz=qux.html');
+      assert.equal(utils.computePathForCache('/index.html', '', '/target/'), path.resolve('/target', 'index.html'));
+      assert.equal(utils.computePathForCache('/folder/index.html', '', '/target/'), path.resolve('/target', 'folder/index.html'));
+      assert.equal(utils.computePathForCache('/script.js', '', '/target/'), path.resolve('/target', 'script.js'));
+      assert.equal(utils.computePathForCache('/page.html', '?foo=bar&baz=qux', '/target/'), path.resolve('/target', 'page.foo=bar&baz=qux.html'));
     });
 
     const test = async (pathname, qs, req) => {

--- a/test/server-utils.test.js
+++ b/test/server-utils.test.js
@@ -251,7 +251,7 @@ describe('Utils Test', () => {
       assert.equal(utils.computePathForCache('/index.html', '', '/target/'), '/target/index.html');
       assert.equal(utils.computePathForCache('/folder/index.html', '', '/target/'), '/target/folder/index.html');
       assert.equal(utils.computePathForCache('/script.js', '', '/target/'), '/target/script.js');
-      assert.equal(utils.computePathForCache('/page.html', '?foo=bar&baz=qux', '/target/'), '/target/page.?foo=bar&baz=qux.html');
+      assert.equal(utils.computePathForCache('/page.html', '?foo=bar&baz=qux', '/target/'), '/target/page.foo=bar&baz=qux.html');
     });
 
     const test = async (pathname, qs, req) => {

--- a/test/server-utils.test.js
+++ b/test/server-utils.test.js
@@ -253,6 +253,7 @@ describe('Utils Test', () => {
       assert.equal(utils.computePathForCache('/folder/index.html', '', '/target/'), path.resolve('/target', 'folder/index.html'));
       assert.equal(utils.computePathForCache('/script.js', '', '/target/'), path.resolve('/target', 'script.js'));
       assert.equal(utils.computePathForCache('/page.html', '?foo=bar&baz=qux', '/target/'), path.resolve('/target', 'page.foo=bar&baz=qux.html'));
+      assert.equal(utils.computePathForCache('/noext', '?foo=bar&baz=qux', '/target/'), path.resolve('/target', 'noext.foo=bar&baz=qux'));
     });
 
     const test = async (pathname, qs, req) => {


### PR DESCRIPTION
Follow up from #1956 which has not been released because of failing Windows tests.

@trieloff @tripodsan any specific reason why `build_win` is currently commented out in the CircleCI config ? I would have seen the problem before merging into main...