### PR TITLE
fix: fix kill implementation

### DIFF
--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -42,7 +42,6 @@ export default class HelixServer extends EventEmitter {
     this._app = express();
     this._port = DEFAULT_PORT;
     this._server = null;
-    this._kill = project.kill;
   }
 
   /**
@@ -134,7 +133,7 @@ export default class HelixServer extends EventEmitter {
   async start() {
     const { log } = this;
     if (this._port !== 0) {
-      if (this._kill && await utils.checkPortInUse(this._port)) {
+      if (this._project.kill && await utils.checkPortInUse(this._port)) {
         await fetch(`http://localhost:${this._port}/.kill`);
       }
       const inUse = await utils.checkPortInUse(this._port);

--- a/src/up.js
+++ b/src/up.js
@@ -51,7 +51,8 @@ export default function up() {
           type: 'int',
           default: 3000,
         })
-        .option('--stop-other', {
+        .option('stop-other', {
+          alias: 'stopOther',
           describe: 'Stop other Helix CLI running on the above port',
           type: 'boolean',
           default: true,

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -64,6 +64,34 @@ describe('Helix Server', () => {
     }
   });
 
+  it('kills other server', async () => {
+    const cwd = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
+    const project = new HelixProject()
+      .withCwd(cwd)
+      .withLogger(console)
+      .withHttpPort(0);
+    await project.init();
+    try {
+      await project.start();
+
+      const project2 = new HelixProject()
+        .withCwd(cwd)
+        .withKill(true)
+        .withHttpPort(project.server.port);
+      await project2.init();
+      try {
+        await project2.start();
+        assert.ok(project2.started, 'server has killed other server.');
+      } catch (e) {
+        assert.fail(`server should have killed the other server. ${e.message}`);
+      } finally {
+        await project2.stop();
+      }
+    } finally {
+      await project.stop();
+    }
+  });
+
   it('deliver static content resource', async () => {
     const cwd = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
     const project = new HelixProject()

--- a/test/up-cli.test.js
+++ b/test/up-cli.test.js
@@ -110,4 +110,10 @@ describe('hlx up', () => {
     sinon.assert.calledWith(mockUp.withCache, '.cache/');
     sinon.assert.calledOnce(mockUp.run);
   });
+
+  it('hlx up can disable kill', async () => {
+    await cli.run(['up', '--stop-other', 'false']);
+    sinon.assert.calledWith(mockUp.withKill, false);
+    sinon.assert.calledOnce(mockUp.run);
+  });
 });


### PR DESCRIPTION
While working on code coverage for the import proxy, I realised that one line on the `kill` feature is not covered by a test. And when the test is written, you see that the implementation is not correct.