### PR TITLE
feat: import - support 301

### DIFF
--- a/src/server/HelixImportServer.js
+++ b/src/server/HelixImportServer.js
@@ -136,8 +136,14 @@ export default class HelixServer extends EventEmitter {
     const respHeaders = ret.headers.plain();
     delete respHeaders['content-encoding'];
     delete respHeaders['content-length'];
-    delete respHeaders.location;
     respHeaders['access-control-allow-origin'] = '*';
+
+    if (respHeaders.location && !respHeaders.location.startsWith('/')) {
+      const u = new URL(respHeaders.location);
+      if (u.origin === host) {
+        respHeaders.location = u.pathname;
+      }
+    }
 
     let buffer;
     if (this._project.cacheDirectory) {

--- a/test/import-cmd.test.js
+++ b/test/import-cmd.test.js
@@ -115,7 +115,7 @@ describe('Integration test for import command', function suite() {
           assert.strictEqual(resp.status, 301);
           assert.strictEqual(resp.headers.get('Location'), '/index.html');
 
-          resp = await fetch(`http://localhost:${cmd.project.server.port}/redirect-with-external-host.html?host=${SAMPLE_HOST}`, {
+          resp = await fetch(`http://localhost:${cmd.project.server.port}/redirect-with-external-host.html`, {
             redirect: 'manual',
             headers: {
               cookie: cookies,


### PR DESCRIPTION
The 301 support got lost while implementing the `hlx import` command. Re-adding it.