### PR TITLE
fix: typo in proxy mode route handler

### DIFF
--- a/src/server/HelixImportServer.js
+++ b/src/server/HelixImportServer.js
@@ -84,7 +84,7 @@ export default class HelixServer extends EventEmitter {
       /* c8 ignore end */
     }
 
-    res.status(404).send(`Unknwon path: ${ctx.path}`);
+    res.status(404).send(`Unknown path: ${ctx.path}`);
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
fix typo in `HelixImportServer.js`

```
res.status(404).send(`Unknown path: ${ctx.path}`);
```