### PR TITLE
feat: install and build importer-ui

### DIFF
--- a/src/import.cmd.js
+++ b/src/import.cmd.js
@@ -15,12 +15,10 @@ import opn from 'open';
 import chalk from 'chalk-template';
 import git from 'isomorphic-git';
 import http from 'isomorphic-git/http/node/index.js';
-import shell from 'shelljs';
 import HelixImportProject from './server/HelixImportProject.js';
 import pkgJson from './package.cjs';
 import AbstractCommand from './abstract.cmd.js';
 
-const IMPORTER_UI_REPO = 'https://github.com/adobe/helix-importer-ui';
 export default class ImportCommand extends AbstractCommand {
   constructor(logger) {
     super(logger);
@@ -88,24 +86,31 @@ export default class ImportCommand extends AbstractCommand {
     const exists = await fse.pathExists(uiFolder);
     if (!exists) {
       this.log.info('Helix Importer UI needs to be installed.');
-      this.log.info(`Cloning ${IMPORTER_UI_REPO} in ${importerFolder}.`);
+      this.log.info(`Cloning ${this._uiRepo} in ${importerFolder}.`);
       // clone the ui project
       await git.clone({
         fs: fse,
         http,
         dir: uiFolder,
-        url: IMPORTER_UI_REPO,
+        url: this._uiRepo,
         ref: 'main',
         depth: 1,
         singleBranch: true,
       });
-      this.log.info('Installing Helix Importer UI project (might take a minute or more)...');
-      const cwd = process.cwd();
-      shell.cd(uiFolder);
-      // using dev mode because it is faster (still at least one minute...)
-      shell.exec('npm run build:dev');
-      shell.cd(cwd);
       this.log.info('Helix Importer UI is ready.');
+    } else {
+      this.log.info('Fetching latest version of the Helix Import UI.');
+      // clone the ui project
+      await git.fetch({
+        fs: fse,
+        http,
+        dir: uiFolder,
+        url: this._uiRepo,
+        ref: 'main',
+        depth: 1,
+        singleBranch: true,
+      });
+      this.log.info('Helix Importer UI is now up-to-date.');
     }
   }
 

--- a/src/import.js
+++ b/src/import.js
@@ -25,7 +25,19 @@ export default function up() {
         .option('open', {
           describe: 'Open a browser window at specified path',
           type: 'string',
-          default: '/tools/importer/helix-webui-importer/index.html',
+          default: '/tools/importer/helix-importer-ui/index.html',
+        })
+        .option('ui-repo', {
+          alias: 'uiRepo',
+          describe: 'Git repository for the Helix Importer UI',
+          type: 'string',
+          default: 'https://github.com/adobe/helix-importer-ui',
+        })
+        .option('skip-ui', {
+          alias: 'skipUI',
+          describe: 'Do not install the Helix Importer UI',
+          type: 'boolean',
+          default: false,
         })
         .option('no-open', {
           // negation of the open option (resets open default)
@@ -71,6 +83,8 @@ export default function up() {
         .withOpen(path.basename(argv.$0) === 'hlx' ? argv.open : false)
         .withKill(argv.stopOther)
         .withCache(argv.cache)
+        .withSkipUI(argv.skipUI)
+        .withUIRepo(argv.uiRepo)
         .run();
     },
   };

--- a/test/import-cli.test.js
+++ b/test/import-cli.test.js
@@ -39,6 +39,8 @@ describe('hlx import', () => {
     mockImport.withHttpPort.returnsThis();
     mockImport.withKill.returnsThis();
     mockImport.withCache.returnsThis();
+    mockImport.withSkipUI.returnsThis();
+    mockImport.withUIRepo.returnsThis();
     mockImport.run.returnsThis();
     cli = (await new CLI().initCommands()).withCommandExecutor('import', mockImport);
   });
@@ -54,7 +56,9 @@ describe('hlx import', () => {
 
   it('hlx import runs w/o arguments', async () => {
     await cli.run(['import']);
-    sinon.assert.calledWith(mockImport.withOpen, '/tools/importer/helix-webui-importer/index.html');
+    sinon.assert.calledWith(mockImport.withOpen, '/tools/importer/helix-importer-ui/index.html');
+    sinon.assert.calledWith(mockImport.withSkipUI, false);
+    sinon.assert.calledWith(mockImport.withUIRepo, 'https://github.com/adobe/helix-importer-ui');
     sinon.assert.calledOnce(mockImport.run);
   });
 
@@ -110,6 +114,18 @@ describe('hlx import', () => {
   it('hlx import can disable kill', async () => {
     await cli.run(['import', '--stop-other', 'false']);
     sinon.assert.calledWith(mockImport.withKill, false);
+    sinon.assert.calledOnce(mockImport.run);
+  });
+
+  it('hlx import can skip ui install', async () => {
+    await cli.run(['import', '--skip-ui']);
+    sinon.assert.calledWith(mockImport.withSkipUI, true);
+    sinon.assert.calledOnce(mockImport.run);
+  });
+
+  it('hlx import can change ui repo', async () => {
+    await cli.run(['import', '--ui-repo', 'https://github.com/adobe/helix-importer-ui#somebranch']);
+    sinon.assert.calledWith(mockImport.withUIRepo, 'https://github.com/adobe/helix-importer-ui#somebranch');
     sinon.assert.calledOnce(mockImport.run);
   });
 });

--- a/test/import-cmd.test.js
+++ b/test/import-cmd.test.js
@@ -441,7 +441,7 @@ describe('Import command - importer ui', function suite() {
     await fse.remove(testRoot);
   });
 
-  this.timeout(180000);
+  this.timeout(240000);
 
   it('import command installs the importer ui', (done) => {
     let error = null;

--- a/test/import-cmd.test.js
+++ b/test/import-cmd.test.js
@@ -433,8 +433,7 @@ describe('Import command - importer ui', function suite() {
     await fse.copy(TEST_DIR, testDir);
 
     nock = new Nock();
-    nock.enableNetConnect(/localhost/);
-    nock.enableNetConnect(/github.com/);
+    nock.enableNetConnect(/localhost|github\.com/);
   });
 
   afterEach(async () => {

--- a/test/import-cmd.test.js
+++ b/test/import-cmd.test.js
@@ -460,7 +460,6 @@ describe('Import command - importer ui', function suite() {
       .on('started', async () => {
         try {
           assert.ok(await fse.pathExists(`${testDir}/tools/importer/helix-importer-ui/index.html`), 'helix-importer-ui project has been cloned');
-          assert.ok(await fse.pathExists(`${testDir}/tools/importer/helix-importer-ui/js/libs/hlx`), 'folder is created by build process');
           await assertHttp(`http://localhost:${cmd.project.server.port}/tools/importer/helix-importer-ui/index.html`, 200);
 
           await myDone();

--- a/test/import-cmd.test.js
+++ b/test/import-cmd.test.js
@@ -423,6 +423,7 @@ describe('Integration test for import command with cache', function suite() {
 });
 
 describe('Import command - importer ui', function suite() {
+  let nock;
   let testDir;
   let testRoot;
 
@@ -430,9 +431,14 @@ describe('Import command - importer ui', function suite() {
     testRoot = await createTestRoot();
     testDir = path.resolve(testRoot, 'import');
     await fse.copy(TEST_DIR, testDir);
+
+    nock = new Nock();
+    nock.enableNetConnect(/localhost/);
+    nock.enableNetConnect(/github.com/);
   });
 
   afterEach(async () => {
+    nock.done();
     await fse.remove(testRoot);
   });
 


### PR DESCRIPTION
Fix #2031 

The importer-ui project build process is really slow (more than one minute), I will look at that separately. 
Another approach could also be to package the importer UI together with the hlx cli...

I also did not implement the git fetch + build if the project is already there mainly because the build process is super slow. Impact is that `hlx import` would always be slow to start.