### PR TITLE
update proxy url when get head or remotes change

### DIFF
--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -114,7 +114,9 @@ export default class UpCommand extends AbstractCommand {
 
     const ref = await GitUtils.getBranch(this.directory);
     const gitUrl = await GitUtils.getOriginURL(this.directory, { ref });
+    let explicitURL = true;
     if (!this._url) {
+      explicitURL = false;
       // check if remote already has the `ref`
       await this.verifyUrl(gitUrl, ref);
     }
@@ -132,7 +134,9 @@ export default class UpCommand extends AbstractCommand {
     try {
       await this._project.init();
 
-      this.watchGit();
+      if (!explicitURL) {
+        this.watchGit();
+      }
     } catch (e) {
       throw Error(`Unable to start Franklin: ${e.message}`);
     }

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -172,7 +172,7 @@ export default class UpCommand extends AbstractCommand {
     });
 
     this._watcher.on('all', (eventType, file) => {
-      if (file.endsWith('.git/HEAD') || file.match(/\.git[/\\]refs[/\\]heads[/\\].+/)) {
+      if (file.endsWith('.git/HEAD') || file.endsWith('.git\\HEAD') || file.match(/\.git[/\\]refs[/\\]heads[/\\].+/)) {
         if (timer) {
           clearTimeout(timer);
         }

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -172,7 +172,7 @@ export default class UpCommand extends AbstractCommand {
     });
 
     this._watcher.on('all', (eventType, file) => {
-      if (file.endsWith('.git/HEAD') || file.match(/\.git\/refs\/heads\/.+/)) {
+      if (file.endsWith('.git/HEAD') || file.match(/\.git[/\\]refs[/\\]heads[/\\].+/)) {
         if (timer) {
           clearTimeout(timer);
         }

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -177,7 +177,7 @@ export default class UpCommand extends AbstractCommand {
           timer = null;
 
           // restart if any of the files is not ignored
-          this.log.info('git HEAD or remotes changed, restarting server...');
+          this.log.info('git HEAD or remotes changed, reconfiguring server...');
           const ref = await GitUtils.getBranch(this.directory);
           const gitUrl = await GitUtils.getOriginURL(this.directory, { ref });
           await this.verifyUrl(gitUrl, ref);

--- a/test/up-cmd.test.js
+++ b/test/up-cmd.test.js
@@ -221,9 +221,9 @@ describe('Integration test for up command with helix pages', function suite() {
           await assertHttp(`http://localhost:${cmd.project.server.port}/not-found.txt`, 404);
           // now switch to a new branch
           switchBranch(testDir, 'new-branch');
-          // wait 1 second for the git branch to be detected
+          // wait 5 seconds for the git branch to be detected
           await new Promise((resolve) => {
-            setTimeout(resolve, 1000);
+            setTimeout(resolve, 5000);
           });
           await myDone();
         } catch (e) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -37,6 +37,14 @@ export function initGit(dir, remote, branch) {
   shell.cd(pwd);
 }
 
+export function switchBranch(dir, branch) {
+  const pwd = shell.pwd();
+  shell.cd(dir);
+  shell.exec(`git checkout -b ${branch}`);
+  shell.cd(pwd);
+  console.log(`switched to branch ${branch} in ${dir}`);
+}
+
 export function clearHelixEnv() {
   const deleted = {};
   Object.keys(process.env).filter((key) => key.startsWith('HLX_')).forEach((key) => {


### PR DESCRIPTION
see https://cq-dev.slack.com/archives/C9KD0TT6G/p1670339689943809

This is the restarting code only (which does not actually restart, just change the proxy URL behind the scenes). Tests weren't as involved as I expected.