### PR TITLE
feat(livereload): add compatibility with codespaces

### DIFF
--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -88,7 +88,18 @@ const utils = {
     if (match) {
       const { index } = match;
       // eslint-disable-next-line no-param-reassign
-      body = `${body.substring(0, index)}<script src="/__internal__/livereload.js"></script>${body.substring(index)}`;
+      let newbody = body.substring(0, index);
+      if (process.env.CODESPACES === 'true') {
+        newbody += `<script>
+window.LiveReloadOptions = { 
+  host: new URL(location.href).hostname.replace(/-[0-9]+\\.preview\\.app\\.github\\.dev/, '-35729-preview.app.github.dev'), 
+  port: 443 
+};
+</script>`;
+      }
+      newbody += '<script src="/__internal__/livereload.js"></script>';
+      newbody += body.substring(index);
+      return newbody;
     }
     return body;
   },

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -92,7 +92,7 @@ const utils = {
       if (process.env.CODESPACES === 'true') {
         newbody += `<script>
 window.LiveReloadOptions = { 
-  host: new URL(location.href).hostname.replace(/-[0-9]+\\.preview\\.app\\.github\\.dev/, '-35729-preview.app.github.dev'), 
+  host: new URL(location.href).hostname.replace(/-[0-9]+\\.preview\\.app\\.github\\.dev/, '-35729.preview.app.github.dev'), 
   port: 443,
   https: true,
 };

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -93,7 +93,8 @@ const utils = {
         newbody += `<script>
 window.LiveReloadOptions = { 
   host: new URL(location.href).hostname.replace(/-[0-9]+\\.preview\\.app\\.github\\.dev/, '-35729-preview.app.github.dev'), 
-  port: 443 
+  port: 443,
+  https: true,
 };
 </script>`;
       }

--- a/test/specs/expected_index_w_lr_nohead_codespaces.html
+++ b/test/specs/expected_index_w_lr_nohead_codespaces.html
@@ -1,6 +1,6 @@
 <html><body>Hello, world. path=/index.md, strain=default<script>
 window.LiveReloadOptions = { 
-  host: new URL(location.href).hostname.replace(/-[0-9]+\.preview\.app\.github\.dev/, '-35729-preview.app.github.dev'), 
+  host: new URL(location.href).hostname.replace(/-[0-9]+\.preview\.app\.github\.dev/, '-35729.preview.app.github.dev'), 
   port: 443,
   https: true,
 };

--- a/test/specs/expected_index_w_lr_nohead_codespaces.html
+++ b/test/specs/expected_index_w_lr_nohead_codespaces.html
@@ -1,6 +1,7 @@
 <html><body>Hello, world. path=/index.md, strain=default<script>
 window.LiveReloadOptions = { 
   host: new URL(location.href).hostname.replace(/-[0-9]+\.preview\.app\.github\.dev/, '-35729-preview.app.github.dev'), 
-  port: 443 
+  port: 443,
+  https: true,
 };
 </script><script src="/__internal__/livereload.js"></script></body></html>

--- a/test/specs/expected_index_w_lr_nohead_codespaces.html
+++ b/test/specs/expected_index_w_lr_nohead_codespaces.html
@@ -1,0 +1,6 @@
+<html><body>Hello, world. path=/index.md, strain=default<script>
+window.LiveReloadOptions = { 
+  host: new URL(location.href).hostname.replace(/-[0-9]+\.preview\.app\.github\.dev/, '-35729-preview.app.github.dev'), 
+  port: 443 
+};
+</script><script src="/__internal__/livereload.js"></script></body></html>


### PR DESCRIPTION
this will tweak the livereload to pull the events from another host, as GH Codespaces creates one host per forwarded port.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
