### PR TITLE
feat: security improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,36 @@ $ hlx up
 The `--open` argument takes a path, eg `--open=/products/`, will cause the browser to be openend
 at the specific location. Disable with `--no-open'.`
 
+### setting up a self-signed cert for using https
+
+1. create the certificate
+
+
+```
+$ openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -out server.crt -keyout server.key -subj "/CN=localhost"
+```
+
+this will create 2 files: `server.crt` and `server.key`
+
+2. start hlx with tls support
+
+```
+$ hlx up --tls-cert server.crt --tls-key server.key
+    ____              __    ___   v14.21.4
+   / __/______ ____  / /__ / (_)__
+  / _// __/ _ `/ _ \/  '_// / / _ \
+ /_/ /_/  \_,_/_//_/_/\_\/_/_/_//_/
+
+info: Starting Franklin dev server v14.21.4
+info: Local Franklin dev server up and running: https://localhost:3000/
+```
+
+3. (optional) Add arguments to .env file:
+
+```
+$ echo -e "HLX_TLS_CERT=server.crt\nHLX_TLS_KEY=server.key" >> .env
+```
+
 ### environment
 
 All the command arguments can also be specified via environment variables. the `.env` file is
@@ -77,15 +107,16 @@ HLX_PAGES_URL=https://stage.myproject.com
 
 #### Up command
 
-| option | variable | default | description |
-|--------|----------|---------|-------------|
-| `--port` | `HLX_PORT` | `3000` | Development server port |
-| `--livereload` | `HLX_LIVERELOAD` | `true` | Enable automatic reloading of modified sources in browser. |
-| `--no-livereload` | `HLX_NO_LIVERELOAD` | `false` | Disable live-reload. |
-| `--open` | `HLX_OPEN` | `/` | Open a browser window at specified path after server start. |
-| `--no-open` | `HLX_NO_OPEN` | `false` | Disable automatic opening of browser window. |
-| `--tls-key` | -- | undefined | Path to .key file (for enabling TLS) |
-| `--tls-cert` | -- | undefined | Path to .pem file (for enabling TLS) |
+| option            | variable            | default     | description                                                 |
+|-------------------|---------------------|-------------|-------------------------------------------------------------|
+| `--port`          | `HLX_PORT`          | `3000`      | Development server port                                     |
+| `--addr`          | `HLX_ADDR`          | `127.0.0.1` | Development server bind address                             |
+| `--livereload`    | `HLX_LIVERELOAD`    | `true`      | Enable automatic reloading of modified sources in browser.  |
+| `--no-livereload` | `HLX_NO_LIVERELOAD` | `false`     | Disable live-reload.                                        |
+| `--open`          | `HLX_OPEN`          | `/`         | Open a browser window at specified path after server start. |
+| `--no-open`       | `HLX_NO_OPEN`       | `false`     | Disable automatic opening of browser window.                |
+| `--tls-key`       | `HLX_TLS_KEY`       | undefined   | Path to .key file (for enabling TLS)                        |
+| `--tls-cert`      | `HLX_TLS_CERT`      | undefined   | Path to .pem file (for enabling TLS)                        |
 
 # Developing Helix CLI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@semantic-release/git": "10.0.1",
         "c8": "7.13.0",
         "eslint": "8.36.0",
+        "esmock": "2.1.0",
         "husky": "8.0.3",
         "junit-report-builder": "3.0.1",
         "lint-staged": "13.2.0",
@@ -3139,6 +3140,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/esmock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/esmock/-/esmock-2.1.0.tgz",
+      "integrity": "sha512-8/2+iFfcB5FMJDBWXmXCY/4GSaI8sMCWUmq2laroQc3y9AI53QMm5Ew25DkW9FMaM8dBH8hmvOr2l3qChJ2JgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16.0"
+      }
     },
     "node_modules/espree": {
       "version": "9.5.0",
@@ -14259,6 +14269,12 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true
+    },
+    "esmock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/esmock/-/esmock-2.1.0.tgz",
+      "integrity": "sha512-8/2+iFfcB5FMJDBWXmXCY/4GSaI8sMCWUmq2laroQc3y9AI53QMm5Ew25DkW9FMaM8dBH8hmvOr2l3qChJ2JgA==",
       "dev": true
     },
     "espree": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "require": "test/setup-env.js",
     "recursive": "true",
     "reporter": "mocha-multi-reporters",
-    "reporter-options": "configFile=.mocha-multi.json"
+    "reporter-options": "configFile=.mocha-multi.json",
+    "loader": "esmock"
   },
   "repository": {
     "type": "git",
@@ -74,6 +75,7 @@
     "@semantic-release/git": "10.0.1",
     "c8": "7.13.0",
     "eslint": "8.36.0",
+    "esmock": "2.1.0",
     "husky": "8.0.3",
     "junit-report-builder": "3.0.1",
     "lint-staged": "13.2.0",

--- a/src/abstract-server.cmd.js
+++ b/src/abstract-server.cmd.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import opn from 'open';
+import { AbstractCommand } from './abstract.cmd.js';
+import { context } from './fetch-utils.js';
+
+export class AbstractServerCommand extends AbstractCommand {
+  constructor(logger) {
+    super(logger);
+    this._httpPort = -1;
+    this._bindAddr = null;
+    this._tls = false;
+    this._tlsCertPath = undefined;
+    this._tlsKeyPath = undefined;
+    this._scheme = 'http';
+    this._stopping = false;
+    this._cache = null;
+  }
+
+  withHttpPort(p) {
+    this._httpPort = p;
+    return this;
+  }
+
+  withBindAddr(a) {
+    this._bindAddr = a;
+    return this;
+  }
+
+  withTLS(tlsKeyPath, tlsCertPath) {
+    if (tlsKeyPath && tlsCertPath) {
+      this._tls = true;
+      this._tlsKeyPath = tlsKeyPath;
+      this._tlsCertPath = tlsCertPath;
+    }
+    return this;
+  }
+
+  withOpen(o) {
+    this._open = o === 'false' ? false : o;
+    return this;
+  }
+
+  withCache(value) {
+    this._cache = value;
+    return this;
+  }
+
+  withKill(value) {
+    this._kill = value;
+    return this;
+  }
+
+  get project() {
+    return this._project;
+  }
+
+  async doStop() {
+    if (this._project) {
+      await this._project.stop();
+      delete this._project;
+    }
+    await context.reset();
+  }
+
+  async stop() {
+    if (this._stopping) {
+      return;
+    }
+    this._stopping = true;
+    await this.doStop();
+    this.emit('stopped', this);
+  }
+
+  async run() {
+    await this.init();
+    await this._project.start();
+    this.emit('started', this);
+    if (this._open) {
+      await this.open(this._open);
+    }
+  }
+
+  async open(href) {
+    let url;
+    try {
+      url = new URL(href.startsWith('/')
+        ? `${this._project.server.scheme}://${this._project.server.hostname}:${this._project.server.port}${href}`
+        : href);
+    } catch (e) {
+      throw Error('invalid argument for --open. either provide an relative url starting with \'/\' or an absolute http(s) url.');
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw Error(`refuse to open non http(s) url (--open): ${url}`);
+    }
+    this.log.info(`opening default browser: ${url.href}`);
+    await opn(url.href);
+  }
+}

--- a/src/abstract.cmd.js
+++ b/src/abstract.cmd.js
@@ -12,7 +12,7 @@
 import EventEmitter from 'events';
 import { getOrCreateLogger } from './log-common.js';
 
-export default class AbstractCommand extends EventEmitter {
+export class AbstractCommand extends EventEmitter {
   constructor(logger) {
     super();
     this._initialized = false;

--- a/src/hack.cmd.js
+++ b/src/hack.cmd.js
@@ -11,7 +11,7 @@
  */
 import chalk from 'chalk-template';
 import opn from 'open';
-import AbstractCommand from './abstract.cmd.js';
+import { AbstractCommand } from './abstract.cmd.js';
 
 export default class HackCommand extends AbstractCommand {
   constructor(logger) {
@@ -37,9 +37,9 @@ export default class HackCommand extends AbstractCommand {
 
   async run() {
     await this.init();
-    const url = `https://github.com/adobe/helix-home/tree/main/hackathons/${this._hackathon}.md`;
+    const url = `https://github.com/adobe/helix-home/tree/main/hackathons/${encodeURIComponent(this._hackathon)}.md`;
     if (this._open) {
-      opn(url, { url: true });
+      await opn(url);
     } else {
       // eslint-disable-next-line no-console
       this.log.info(chalk`Check out the Franklin Hackathon at {blue ${url}}`);

--- a/src/import.js
+++ b/src/import.js
@@ -51,13 +51,18 @@ export default function up() {
           type: 'int',
           default: 3001,
         })
+        .option('addr', {
+          describe: 'Bind import server on addr. use * to bind to any address and allow external connections.',
+          type: 'string',
+          default: '127.0.0.1',
+        })
         .option('stop-other', {
           alias: 'stopOther',
           describe: 'Stop other Franklin CLI running on the above port',
           type: 'boolean',
           default: true,
         })
-        .group(['port', 'stop-other'], 'Server options')
+        .group(['port', 'addr', 'stop-other'], 'Server options')
         .option('cache', {
           describe: 'Path to local folder to cache the responses',
           type: 'string',
@@ -78,6 +83,7 @@ export default function up() {
       /* c8 ignore end */
       await executor
         .withHttpPort(argv.port)
+        .withBindAddr(argv.addr)
         // only open  browser window when executable is `hlx`
         // this prevents the window to be opened during integration tests
         .withOpen(path.basename(argv.$0) === 'hlx' ? argv.open : false)

--- a/src/server/BaseProject.js
+++ b/src/server/BaseProject.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import EventEmitter from 'events';
+import { ConsoleLogger, deriveLogger, SimpleInterface } from '@adobe/helix-log';
+
+export class BaseProject extends EventEmitter {
+  constructor(Server) {
+    super();
+    this._cwd = process.cwd();
+    this._server = new Server(this);
+    this._server.on('stopped', async () => {
+      await this.stop();
+    });
+    this._stopping = false;
+    this._logger = null;
+    this._cacheDirectory = null;
+    this._kill = false;
+  }
+
+  withCwd(cwd) {
+    this._cwd = cwd;
+    return this;
+  }
+
+  withKill(kill) {
+    this._kill = !!kill;
+    return this;
+  }
+
+  withHttpPort(port) {
+    this._server.withPort(port);
+    return this;
+  }
+
+  withBindAddr(addr) {
+    this._server.withAddr(addr);
+    return this;
+  }
+
+  withTLS(key, cert) {
+    this._server.withTLS(key, cert);
+    return this;
+  }
+
+  withLogger(logger) {
+    this._logger = logger;
+    return this;
+  }
+
+  withCacheDirectory(value) {
+    this._cacheDirectory = value;
+    return this;
+  }
+
+  get log() {
+    return this._logger;
+  }
+
+  get started() {
+    return this._server.isStarted();
+  }
+
+  get cacheDirectory() {
+    return this._cacheDirectory;
+  }
+
+  get directory() {
+    return this._cwd;
+  }
+
+  get kill() {
+    return this._kill;
+  }
+
+  /**
+   * Returns the helix server
+   * @returns {HelixServer}
+   */
+  get server() {
+    return this._server;
+  }
+
+  async init() {
+    if (!this._logger) {
+      this._logger = new SimpleInterface({
+        logger: new ConsoleLogger(),
+        level: 'debug',
+        defaultFields: {
+          category: 'hlx',
+        },
+        filter: (fields) => {
+          // eslint-disable-next-line no-param-reassign
+          fields.message[0] = `[${fields.category}] ${fields.message[0]}`;
+          // eslint-disable-next-line no-param-reassign
+          delete fields.category;
+          return fields;
+        },
+      });
+    } else {
+      this._logger = deriveLogger(this._logger, {
+        defaultFields: {
+          category: 'hlx',
+        },
+      });
+    }
+    return this;
+  }
+
+  async start() {
+    await this._server.start(this);
+    return this;
+  }
+
+  async doStop() {
+    await this._server.stop();
+  }
+
+  async stop() {
+    if (this._stopping) {
+      return this;
+    }
+    this._stopping = true;
+    this.emit('stopping');
+    await this.doStop();
+    this.emit('stopped');
+    return this;
+  }
+}

--- a/src/server/BaseServer.js
+++ b/src/server/BaseServer.js
@@ -96,6 +96,12 @@ export class BaseServer extends EventEmitter {
     return this._addr;
   }
 
+  get hostname() {
+    return this._addr === '127.0.0.1' || this._addr === '0.0.0.0'
+      ? 'localhost'
+      : this._addr;
+  }
+
   get scheme() {
     return this._scheme;
   }
@@ -135,10 +141,7 @@ export class BaseServer extends EventEmitter {
         }
         this._port = this._server.address().port;
         this._addr = this._server.address().address;
-        this._addrName = this._addr === '127.0.0.1' || this._addr === '0.0.0.0'
-          ? 'localhost'
-          : this._addr;
-        log.info(`Local Franklin dev server up and running: ${this._scheme}://${this._addrName}:${this._port}/`);
+        log.info(`Local Franklin dev server up and running: ${this.scheme}://${this.hostname}:${this.port}/`);
         if (this._project.proxyUrl) {
           log.info(`Enabled reverse proxy to ${this._project.proxyUrl}`);
         }

--- a/src/server/BaseServer.js
+++ b/src/server/BaseServer.js
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import https from 'https';
+import EventEmitter from 'events';
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import { fetch } from '../fetch-utils.js';
+import utils from './utils.js';
+import packageJson from '../package.cjs';
+
+const DEFAULT_PORT = 3000;
+
+/**
+ * Wraps the route middleware so it can catch potential promise rejections
+ * during the async invocation.
+ *
+ * @param {ExpressMiddleware} fn an extended express middleware function
+ * @returns {ExpressMiddleware} an express middleware function.
+ */
+export function asyncHandler(fn) {
+  return (req, res, next) => (Promise.resolve(fn(req, res, next)).catch(next));
+}
+
+export class BaseServer extends EventEmitter {
+  /**
+   * Creates a new HelixServer for the given project.
+   * @param {BaseProject} project
+   */
+  constructor(project) {
+    super();
+    this._project = project;
+    this._app = express();
+    this._port = DEFAULT_PORT;
+    this._addr = '127.0.0.1';
+    this._tls = false;
+    this._scheme = 'http';
+    this._key = '';
+    this._cert = '';
+    this._server = null;
+    this._sockets = new Set();
+  }
+
+  /**
+   * Returns the logger.
+   * @returns {Logger} the logger.
+   */
+  get log() {
+    return this._project.log;
+  }
+
+  async setupApp() {
+    this._app.use(cookieParser());
+    this._app.get('/.kill', async (req, res) => {
+      res.send('Goodbye!');
+      this.stop();
+    });
+  }
+
+  withPort(port) {
+    this._port = port;
+    return this;
+  }
+
+  withAddr(addr) {
+    // prefer IPv4
+    this._addr = addr === '*' ? '0.0.0.0' : addr;
+    return this;
+  }
+
+  withTLS(key, cert) {
+    this._tls = true;
+    this._scheme = 'https';
+    this._key = key;
+    this._cert = cert;
+    return this;
+  }
+
+  isStarted() {
+    return this._server !== null;
+  }
+
+  get port() {
+    return this._port;
+  }
+
+  get addr() {
+    return this._addr;
+  }
+
+  get scheme() {
+    return this._scheme;
+  }
+
+  get app() {
+    return this._app;
+  }
+
+  async start() {
+    const { log } = this;
+    if (this._port !== 0) {
+      let retries = 1;
+      if (this._project.kill && await utils.checkPortInUse(this._port, this._addr)) {
+        const res = await fetch(`${this._scheme}://${this._addr}:${this._port}/.kill`);
+        await res.text();
+        retries = 10;
+      }
+      let inUse = true;
+      while (inUse && retries > 0) {
+        // eslint-disable-next-line no-await-in-loop
+        inUse = await utils.checkPortInUse(this._port, this._addr);
+        if (inUse) {
+          // eslint-disable-next-line no-await-in-loop,no-promise-executor-return
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        retries -= 1;
+      }
+      if (inUse) {
+        throw new Error(`Port ${this._port} already in use by another process.`);
+      }
+    }
+    log.info(`Starting Franklin dev server v${packageJson.version}`);
+    await new Promise((resolve, reject) => {
+      const listenCb = (err) => {
+        if (err) {
+          reject(new Error(`Error while starting ${this._scheme} server: ${err}`));
+        }
+        this._port = this._server.address().port;
+        this._addr = this._server.address().address;
+        this._addrName = this._addr === '127.0.0.1' || this._addr === '0.0.0.0'
+          ? 'localhost'
+          : this._addr;
+        log.info(`Local Franklin dev server up and running: ${this._scheme}://${this._addrName}:${this._port}/`);
+        if (this._project.proxyUrl) {
+          log.info(`Enabled reverse proxy to ${this._project.proxyUrl}`);
+        }
+        this._server.on('connection', (socket) => {
+          log.debug(`new connection from ${socket.remoteAddress}:${socket.remotePort}`);
+          this._sockets.add(socket);
+          socket.once('close', () => {
+            log.debug(`closed connection from ${socket.remoteAddress}:${socket.remotePort}`);
+            this._sockets.delete(socket);
+          });
+        });
+        resolve();
+      };
+      if (this._tls) {
+        this._server = https.createServer({
+          key: this._key,
+          cert: this._cert,
+        }, this._app);
+        this._server.listen(this._port, this._addr, listenCb);
+      } else {
+        this._server = this._app.listen(this._port, this._addr, listenCb);
+      }
+    });
+    await this.setupApp();
+    this.emit('started', this.server);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async doStop() {
+    // ignore
+  }
+
+  async stop() {
+    if (!this._server) {
+      return;
+    }
+    const server = this._server;
+    this._server = null;
+    this.emit('stopping');
+    await new Promise((resolve, reject) => {
+      this.log.debug('Stopping Franklin dev server..');
+      for (const socket of this._sockets) {
+        socket.destroy();
+        this._sockets.delete(socket);
+      }
+      server.close((err) => {
+        if (err) {
+          reject(new Error(`Error while stopping http server: ${err}`));
+        }
+        this.log.info('Franklin dev server stopped.');
+        resolve();
+      });
+    });
+    await this.doStop();
+    this.emit('stopped');
+  }
+}

--- a/src/server/HelixImportProject.js
+++ b/src/server/HelixImportProject.js
@@ -9,107 +9,22 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ConsoleLogger, deriveLogger, SimpleInterface } from '@adobe/helix-log';
-import HelixImportServer from './HelixImportServer.js';
+import { HelixImportServer } from './HelixImportServer.js';
+import { BaseProject } from './BaseProject.js';
 
-export default class HelixProject {
+export class HelixImportProject extends BaseProject {
   constructor() {
-    this._cwd = process.cwd();
-    this._server = new HelixImportServer(this);
-    this._logger = null;
-    this._cacheDirectory = null;
-    this._kill = false;
-  }
-
-  withCwd(cwd) {
-    this._cwd = cwd;
-    return this;
-  }
-
-  withKill(kill) {
-    this._kill = !!kill;
-    return this;
-  }
-
-  withHttpPort(port) {
-    this._server.withPort(port);
-    return this;
-  }
-
-  withLogger(logger) {
-    this._logger = logger;
-    return this;
-  }
-
-  withCacheDirectory(value) {
-    this._cacheDirectory = value;
-    return this;
-  }
-
-  get log() {
-    return this._logger;
-  }
-
-  get started() {
-    return this._server.isStarted();
-  }
-
-  get cacheDirectory() {
-    return this._cacheDirectory;
-  }
-
-  get directory() {
-    return this._cwd;
-  }
-
-  get kill() {
-    return this._kill;
-  }
-
-  /**
-   * Returns the helix server
-   * @returns {HelixImportServer}
-   */
-  get server() {
-    return this._server;
-  }
-
-  async init() {
-    if (!this._logger) {
-      this._logger = new SimpleInterface({
-        logger: new ConsoleLogger(),
-        level: 'debug',
-        defaultFields: {
-          category: 'hlx',
-        },
-        filter: (fields) => {
-          // eslint-disable-next-line no-param-reassign
-          fields.message[0] = `[${fields.category}] ${fields.message[0]}`;
-          // eslint-disable-next-line no-param-reassign
-          delete fields.category;
-          return fields;
-        },
-      });
-    } else {
-      this._logger = deriveLogger(this._logger, {
-        defaultFields: {
-          category: 'hlx',
-        },
-      });
-    }
-
-    return this;
+    super(HelixImportServer);
   }
 
   async start() {
     this.log.debug('Launching Franklin import server for importing content...');
-    await this._server.start(this);
+    await super.start();
     return this;
   }
 
-  async stop() {
+  async doStop() {
     this.log.debug('Stopping Franklin import server..');
-    await this._server.stop();
-    return this;
+    await super.doStop();
   }
 }

--- a/src/server/HelixImportServer.js
+++ b/src/server/HelixImportServer.js
@@ -34,6 +34,11 @@ export class HelixImportServer extends BaseServer {
     // try to serve static
     try {
       const filePath = path.join(this._project.directory, ctx.path);
+      if (path.relative(this._project.directory, filePath).startsWith('..')) {
+        log.info(`refuse to serve file outside the project directory: ${filePath}`);
+        res.status(403).send('');
+        return;
+      }
       log.debug('trying to serve local file', filePath);
       await sendFile(filePath, {
         dotfiles: 'allow',

--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -45,6 +45,13 @@ export class HelixServer extends BaseServer {
     const { log } = this;
     const proxyUrl = new URL(this._project.proxyUrl);
 
+    const filePath = path.join(this._project.directory, ctx.path);
+    if (path.relative(this._project.directory, filePath).startsWith('..')) {
+      log.info(`refuse to serve file outside the project directory: ${filePath}`);
+      res.status(403).send('');
+      return;
+    }
+
     const liveReload = this._liveReload;
     if (liveReload) {
       liveReload.startRequest(ctx.requestId, ctx.path);
@@ -52,7 +59,6 @@ export class HelixServer extends BaseServer {
 
     // try to serve static
     try {
-      const filePath = path.join(this._project.directory, ctx.path);
       log.debug('trying to serve local file', filePath);
       await sendFile(filePath, {
         dotfiles: 'allow',

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -390,9 +390,9 @@ window.LiveReloadOptions = {
    * Checks if the given port is already in use on any addr. This is used to prevent starting a
    * server on the same port with an existing socket bound to 0.0.0.0 and SO_REUSEADDR.
    * @param port
-   * @return {Promise} that resolves `true` if the port is in use.
+   @param addr   * @return {Promise} that resolves `true` if the port is in use.
    */
-  checkPortInUse(port) {
+  checkPortInUse(port, addr = '0.0.0.0') {
     return new Promise((resolve, reject) => {
       let socket;
 
@@ -417,7 +417,7 @@ window.LiveReloadOptions = {
         cleanUp();
       });
 
-      socket.connect(port, () => {
+      socket.connect(port, addr, () => {
         resolve(true);
         cleanUp();
       });

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -12,56 +12,15 @@
 import fs from 'fs/promises';
 import path from 'path';
 import fse from 'fs-extra';
-import opn from 'open';
 import chalk from 'chalk-template';
 import chokidar from 'chokidar';
 import { HelixProject } from './server/HelixProject.js';
 import GitUtils from './git-utils.js';
 import pkgJson from './package.cjs';
-import { fetch, context } from './fetch-utils.js';
-import AbstractCommand from './abstract.cmd.js';
+import { fetch } from './fetch-utils.js';
+import { AbstractServerCommand } from './abstract-server.cmd.js';
 
-export default class UpCommand extends AbstractCommand {
-  constructor(logger) {
-    super(logger);
-    this._httpPort = -1;
-    this._bindAddr = null;
-    this._tls = false;
-    this._tlsCertPath = undefined;
-    this._tlsKeyPath = undefined;
-    this._scheme = 'http';
-    this._open = '/';
-    this._liveReload = false;
-    this._url = null;
-    this._cache = null;
-    this._printIndex = false;
-    this._stopping = false;
-  }
-
-  withHttpPort(p) {
-    this._httpPort = p;
-    return this;
-  }
-
-  withBindAddr(a) {
-    this._bindAddr = a;
-    return this;
-  }
-
-  withTLS(tlsKeyPath, tlsCertPath) {
-    if (tlsKeyPath && tlsCertPath) {
-      this._tls = true;
-      this._tlsKeyPath = tlsKeyPath;
-      this._tlsCertPath = tlsCertPath;
-    }
-    return this;
-  }
-
-  withOpen(o) {
-    this._open = o === 'false' ? false : o;
-    return this;
-  }
-
+export default class UpCommand extends AbstractServerCommand {
   withLiveReload(value) {
     this._liveReload = value;
     return this;
@@ -72,45 +31,21 @@ export default class UpCommand extends AbstractCommand {
     return this;
   }
 
-  withCache(value) {
-    this._cache = value;
-    return this;
-  }
-
   withPrintIndex(value) {
     this._printIndex = value;
     return this;
   }
 
-  withKill(value) {
-    this._kill = value;
-    return this;
-  }
-
-  get project() {
-    return this._project;
-  }
-
-  async stop() {
-    if (this._stopping) {
-      return;
-    }
-    this._stopping = true;
-    if (this._project) {
-      await this._project.stop();
-      delete this._project;
-    }
+  async doStop() {
+    await super.doStop();
     if (this._watcher) {
       const watcher = this._watcher;
       delete this._watcher;
       await watcher.close();
     }
-    await context.reset();
-    this.log.info('Franklin project stopped.');
-    this.emit('stopped', this);
   }
 
-  async setup() {
+  async init() {
     await super.init();
     // check for git repository
     try {
@@ -263,17 +198,5 @@ export default class UpCommand extends AbstractCommand {
         }, 100);
       }
     });
-  }
-
-  async run() {
-    await this.setup();
-    await this._project.start();
-    this.emit('started', this);
-    if (this._open) {
-      const url = this._open.startsWith('/')
-        ? `${this._scheme}://localhost:${this._project.server.port}${this._open}`
-        : this._open;
-      await opn(url);
-    }
   }
 }

--- a/src/up.js
+++ b/src/up.js
@@ -51,6 +51,11 @@ export default function up() {
           type: 'int',
           default: 3000,
         })
+        .option('addr', {
+          describe: 'Bind development server on addr. use * to bind to any address and allow external connections.',
+          type: 'string',
+          default: '127.0.0.1',
+        })
         .option('tls-cert', {
           alias: 'tlsCert',
           describe: 'File location for your .pem file for local TLS support',
@@ -75,7 +80,7 @@ export default function up() {
           type: 'boolean',
           default: false,
         })
-        .group(['port'], 'Server options')
+        .group(['port', 'add'], 'Server options')
         .option('url', {
           alias: ['pagesUrl', 'pages-url'],
           describe: 'The origin url to fetch content from.',
@@ -99,6 +104,7 @@ export default function up() {
 
       await executor
         .withHttpPort(argv.port)
+        .withBindAddr(argv.addr)
         // only open  browser window when executable is `hlx`
         // this prevents the window to be opened during integration tests
         .withOpen(path.basename(argv.$0) === 'hlx' ? argv.open : false)

--- a/test/abstract-server-cmd.test.js
+++ b/test/abstract-server-cmd.test.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import esmock from 'esmock';
+import { AbstractServerCommand } from '../src/abstract-server.cmd.js';
+
+describe('AbstractServerCommand test', () => {
+  it('open rejects invalid path argument', async () => {
+    const cmd = new AbstractServerCommand();
+    // eslint-disable-next-line no-underscore-dangle
+    cmd._project = { server: { hostname: 'localhost', scheme: 'http', port: 3000 } };
+    await assert.rejects(cmd.open('foo'), Error('invalid argument for --open. either provide an relative url starting with \'/\' or an absolute http(s) url.'));
+  });
+
+  it('open rejects invalid scheme argument', async () => {
+    const cmd = new AbstractServerCommand();
+    // eslint-disable-next-line no-underscore-dangle
+    cmd._project = { server: { hostname: 'localhost', scheme: 'http', port: 3000 } };
+    await assert.rejects(cmd.open('file://etc/passwd'), Error('refuse to open non http(s) url (--open): file://etc/passwd'));
+  });
+
+  it('constructs valid url from path', async () => {
+    let opened;
+    const { AbstractServerCommand: MockedCommand } = await esmock('../src/abstract-server.cmd.js', {
+      open: (url) => {
+        opened = url;
+      },
+    });
+    const cmd = new MockedCommand();
+    // eslint-disable-next-line no-underscore-dangle
+    cmd._project = { server: { hostname: 'localhost', scheme: 'http', port: 3000 } };
+    await cmd.open('/"; Start calc.exe; echo "foo');
+    assert.strictEqual(opened, 'http://localhost:3000/%22;%20Start%20calc.exe;%20echo%20%22foo');
+  });
+});

--- a/test/fixtures/all.env
+++ b/test/fixtures/all.env
@@ -3,21 +3,22 @@
 #
 
 # global
-HLX_LOG_LEVEL = debug
-HLX_LOG_FILE = test.log
+HLX_LOG_LEVEL=debug
+HLX_LOG_FILE=test.log
 
 # deploy + package + clean + build + up
-HLX_TARGET = foo
+HLX_TARGET=foo
 
 # build + up
-HLX_FILES = *.htl,*.js
+HLX_FILES=*.htl,*.js
 
 # up
-HLX_HOST = www.project-helix.io
-HLX_OPEN = false
-HLX_LIVERELOAD = false
-HLX_PORT = 1234
-HLX_LOCAL_REPO = ., ../foo-content, ../bar-content
+HLX_HOST=www.project-helix.io
+HLX_OPEN=false
+HLX_LIVERELOAD=false
+HLX_PORT=1234
+HLX_ADDR=*
+HLX_LOCAL_REPO="., ../foo-content, ../bar-content"
 #HLX_SAVE_CONFIG <forbidden use through env>
 HLX_DEV_DEFAULT={"SECRET1": "VALUE1", "SECRET2": 5000}
 HLX_DEV_DEFAULT_FILE=defaults.json
@@ -26,41 +27,41 @@ HLX_DEFAULT={"SECRET2": "VALUE2"}
 HLX_DEFAULT_FILE=defaults.env
 
 # package
-HLX_FORCE = true
+HLX_FORCE=true
 
 # package + deploy
-HLX_MINIFY = true
+HLX_MINIFY=true
 
 # deploy + publish + perf
-HLX_FASTLY_NAMESPACE = 1234
-HLX_FASTLY_AUTH = foobar
+HLX_FASTLY_NAMESPACE=1234
+HLX_FASTLY_AUTH=foobar
 
 # deploy + publish
-HLX_AUTO = true
-HLX_DRY_RUN = true
+HLX_AUTO=true
+HLX_DRY_RUN=true
 
 # deploy
-HLX_CIRCLECI_AUTH = foobar
-HLX_PACKAGE = ignore
-HLX_DIRTY = true
+HLX_CIRCLECI_AUTH=foobar
+HLX_PACKAGE=ignore
+HLX_DIRTY=true
 
-HLX_WSK_AUTH = foobar
-HLX_WSK_NAMESPACE = 1234
-HLX_WSK_HOST = myruntime.net
-HLX_SVC_RESOLVE_GIT_REF = resolve.api
+HLX_WSK_AUTH=foobar
+HLX_WSK_NAMESPACE=1234
+HLX_WSK_HOST=myruntime.net
+HLX_SVC_RESOLVE_GIT_REF=resolve.api
 
 #HLX_DEFAULT <forbidden use through env>
 #HLX_ADD = <forbidden use through env>
 
 # publish
-HLX_API_PUBLISH = foobar.api
-HLX_GITHUB_TOKEN = github-token-foobar
-HLX_UPDATE_BOT_CONFIG = true
-HLX_API_CONFIG_PURGE = purge.api
+HLX_API_PUBLISH=foobar.api
+HLX_GITHUB_TOKEN=github-token-foobar
+HLX_UPDATE_BOT_CONFIG=true
+HLX_API_CONFIG_PURGE=purge.api
 
 # perf
-HLX_JUNIT = some-results.xml
-HLX_DEVICE = iPad
-HLX_CONNECTION = good2G
-HLX_LOCATION = California
+HLX_JUNIT=some-results.xml
+HLX_DEVICE=iPad
+HLX_CONNECTION=good2G
+HLX_LOCATION=California
 

--- a/test/hack-cli.test.js
+++ b/test/hack-cli.test.js
@@ -12,6 +12,7 @@
 /* eslint-env mocha */
 import assert from 'assert';
 import { logging } from '@adobe/helix-testutils';
+import esmock from 'esmock';
 import hack from '../src/hack.js';
 import CLI from '../src/cli.js';
 import HackCommand from '../src/hack.cmd.js';
@@ -32,5 +33,19 @@ describe('Test hlx hack', () => {
       .run();
     const log = logger.getOutput();
     assert.ok(log.indexOf(`/hackathons/${hackathon}.md`) > 0);
+  });
+
+  it('hlx hack opens browser', async () => {
+    let opened;
+    const MockedCommand = await esmock('../src/hack.cmd.js', {
+      open: (url) => {
+        opened = url;
+      },
+    });
+    await new MockedCommand()
+      .withHackathon('test$(calc.exe)test')
+      .withOpen(true)
+      .run();
+    assert.strictEqual(opened, 'https://github.com/adobe/helix-home/tree/main/hackathons/test%24(calc.exe)test.md');
   });
 });

--- a/test/import-cli.test.js
+++ b/test/import-cli.test.js
@@ -37,6 +37,7 @@ describe('hlx import', () => {
     mockImport = sinon.createStubInstance(ImportCommand);
     mockImport.withOpen.returnsThis();
     mockImport.withHttpPort.returnsThis();
+    mockImport.withBindAddr.returnsThis();
     mockImport.withKill.returnsThis();
     mockImport.withCache.returnsThis();
     mockImport.withSkipUI.returnsThis();
@@ -102,6 +103,12 @@ describe('hlx import', () => {
   it('hlx import can specify port number to run proxy server on', async () => {
     await cli.run(['import', '--port', '3210']);
     sinon.assert.calledWith(mockImport.withHttpPort, 3210);
+    sinon.assert.calledOnce(mockImport.run);
+  });
+
+  it('hlx import can specify bind address to run development server on', async () => {
+    await cli.run(['import', '--addr', '192.168.1.7']);
+    sinon.assert.calledWith(mockImport.withBindAddr, '192.168.1.7');
     sinon.assert.calledOnce(mockImport.run);
   });
 

--- a/test/import-cmd.test.js
+++ b/test/import-cmd.test.js
@@ -28,7 +28,7 @@ describe('Integration test for import command', function suite() {
 
   beforeEach(async () => {
     nock = new Nock();
-    nock.enableNetConnect(/localhost/);
+    nock.enableNetConnect(/127.0.0.1/);
   });
 
   afterEach(() => {
@@ -80,9 +80,9 @@ describe('Integration test for import command', function suite() {
       .on('started', async () => {
         try {
           // test proxy
-          await assertHttp(`http://localhost:${cmd.project.server.port}/index.html`, 403);
+          await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/index.html`, 403);
 
-          let resp = await fetch(`http://localhost:${cmd.project.server.port}/index.html?host=${SAMPLE_HOST}`);
+          let resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/index.html?host=${SAMPLE_HOST}`);
           assert.strictEqual(resp.status, 200);
           let text = await resp.text();
           assert.strictEqual(text.trim(), content.index);
@@ -90,7 +90,7 @@ describe('Integration test for import command', function suite() {
           assert.equal(cookies, `hlx-proxyhost=${encodeURIComponent(SAMPLE_HOST)}; Path=/`);
 
           // "host" cookie has been set and host query param is not required anymore
-          resp = await fetch(`http://localhost:${cmd.project.server.port}/index.html`, {
+          resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/index.html`, {
             headers: {
               cookie: cookies,
             },
@@ -99,7 +99,7 @@ describe('Integration test for import command', function suite() {
           text = await resp.text();
           assert.strictEqual(text.trim(), content.index);
 
-          resp = await fetch(`http://localhost:${cmd.project.server.port}/logo.svg`, {
+          resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/logo.svg`, {
             headers: {
               cookie: cookies,
             },
@@ -108,14 +108,14 @@ describe('Integration test for import command', function suite() {
           text = await resp.text();
           assert.strictEqual(text.trim(), content.img);
 
-          resp = await fetch(`http://localhost:${cmd.project.server.port}/not-found.txt`, {
+          resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/not-found.txt`, {
             headers: {
               cookie: cookies,
             },
           });
           assert.strictEqual(resp.status, 404);
 
-          resp = await fetch(`http://localhost:${cmd.project.server.port}/redirect.html`, {
+          resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/redirect.html`, {
             redirect: 'manual',
             headers: {
               cookie: cookies,
@@ -124,7 +124,7 @@ describe('Integration test for import command', function suite() {
           assert.strictEqual(resp.status, 301);
           assert.strictEqual(resp.headers.get('Location'), '/index.html');
 
-          resp = await fetch(`http://localhost:${cmd.project.server.port}/redirect-with-host.html`, {
+          resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/redirect-with-host.html`, {
             redirect: 'manual',
             headers: {
               cookie: cookies,
@@ -133,7 +133,7 @@ describe('Integration test for import command', function suite() {
           assert.strictEqual(resp.status, 301);
           assert.strictEqual(resp.headers.get('Location'), '/index.html');
 
-          resp = await fetch(`http://localhost:${cmd.project.server.port}/redirect-with-external-host.html`, {
+          resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/redirect-with-external-host.html`, {
             redirect: 'manual',
             headers: {
               cookie: cookies,
@@ -142,7 +142,7 @@ describe('Integration test for import command', function suite() {
           assert.strictEqual(resp.status, 301);
           assert.strictEqual(resp.headers.get('Location'), 'https://www.somewhereelse.com');
 
-          resp = await fetch(`http://localhost:${cmd.project.server.port}/index-with-cookie.html`, {
+          resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/index-with-cookie.html`, {
             headers: {
               cookie: cookies,
             },
@@ -153,7 +153,7 @@ describe('Integration test for import command', function suite() {
           cookies = resp.headers.get('set-cookie');
           assert.equal(cookies, `hlx-proxyhost=${encodeURIComponent(SAMPLE_HOST)}; Path=/`);
 
-          resp = await fetch(`http://localhost:${cmd.project.server.port}/page-with-security.html`, {
+          resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/page-with-security.html`, {
             redirect: 'manual',
             headers: {
               cookie: cookies,
@@ -164,10 +164,10 @@ describe('Integration test for import command', function suite() {
           assert.strictEqual(resp.headers.get('x-frame-options'), null);
 
           // /tools is delivered for local project folder
-          const js = await assertHttp(`http://localhost:${cmd.project.server.port}/tools/importer/import.js`, 200);
+          const js = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/tools/importer/import.js`, 200);
           assert.strictEqual(js.trim(), '// import.js code');
 
-          await assertHttp(`http://localhost:${cmd.project.server.port}/tools/not-found.txt`, 404);
+          await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/tools/not-found.txt`, 404);
 
           await myDone();
         } catch (e) {
@@ -237,7 +237,7 @@ describe('Integration test for import command', function suite() {
     cmd
       .on('started', async () => {
         try {
-          const ret = await assertHttp(`http://localhost:${cmd.project.server.port}/index.html?host=${SAMPLE_HOST}`, 200);
+          const ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/index.html?host=${SAMPLE_HOST}`, 200);
           assert.strictEqual(ret.trim(), expected.index.trim());
 
           await myDone();
@@ -273,7 +273,7 @@ describe('Integration test for import command', function suite() {
     cmd
       .on('started', async () => {
         try {
-          const resp = await fetch(`http://localhost:${cmd.project.server.port}/index.html?host=${SAMPLE_HOST}`, {
+          const resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/index.html?host=${SAMPLE_HOST}`, {
             headers: {
               referer: 'http://localhost',
             },
@@ -304,7 +304,7 @@ describe('Integration test for import command with cache', function suite() {
     testDir = path.resolve(testRoot, 'import');
     await fse.copy(TEST_DIR, testDir);
     nock = new Nock();
-    nock.enableNetConnect(/localhost/);
+    nock.enableNetConnect(/127.0.0.1/);
   });
 
   afterEach(async () => {
@@ -363,59 +363,59 @@ describe('Integration test for import command with cache', function suite() {
       .on('started', async () => {
         try {
           const assertRequests = async () => {
-            let resp = await fetch(`http://localhost:${cmd.project.server.port}/index.html?host=${SAMPLE_HOST}`);
+            let resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/index.html?host=${SAMPLE_HOST}`);
             assert.strictEqual(resp.status, 200);
             let ret = await resp.text();
             assert.strictEqual(ret.trim(), content.index);
             let cookies = resp.headers.get('set-cookie');
             assert.equal(cookies, `hlx-proxyhost=${encodeURIComponent(SAMPLE_HOST)}; Path=/`);
 
-            ret = await assertHttp(`http://localhost:${cmd.project.server.port}/?host=${SAMPLE_HOST}`, 200);
+            ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/?host=${SAMPLE_HOST}`, 200);
             assert.strictEqual(ret.trim(), content.index);
-            ret = await assertHttp(`http://localhost:${cmd.project.server.port}/folder/page.html?foo=bar&baz=qux&host=${SAMPLE_HOST}`, 200);
+            ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/folder/page.html?foo=bar&baz=qux&host=${SAMPLE_HOST}`, 200);
             assert.strictEqual(ret.trim(), content.page1);
-            ret = await assertHttp(`http://localhost:${cmd.project.server.port}/folder/page.html?foo=bar&baz=othervalue&host=${SAMPLE_HOST}`, 200);
+            ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/folder/page.html?foo=bar&baz=othervalue&host=${SAMPLE_HOST}`, 200);
             assert.strictEqual(ret.trim(), content.page2);
-            await assertHttp(`http://localhost:${cmd.project.server.port}/not-found.txt?host=${SAMPLE_HOST}`, 404);
-            ret = await assertHttp(`http://localhost:${cmd.project.server.port}/page.plain.html?host=${SAMPLE_HOST}`, 200);
+            await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/not-found.txt?host=${SAMPLE_HOST}`, 404);
+            ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/page.plain.html?host=${SAMPLE_HOST}`, 200);
             assert.strictEqual(ret.trim(), content.plain);
-            ret = await assertHttp(`http://localhost:${cmd.project.server.port}/logo.svg?host=${SAMPLE_HOST}`, 200);
+            ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/logo.svg?host=${SAMPLE_HOST}`, 200);
             assert.strictEqual(ret.trim(), content.img);
 
-            resp = await fetch(`http://localhost:${cmd.project.server.port}/redirect.html?host=${SAMPLE_HOST}`, {
+            resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/redirect.html?host=${SAMPLE_HOST}`, {
               redirect: 'manual',
             });
             assert.strictEqual(resp.status, 301);
             assert.strictEqual(resp.headers.get('Location'), '/index.html');
 
-            resp = await fetch(`http://localhost:${cmd.project.server.port}/redirect-with-host.html?host=${SAMPLE_HOST}`, {
+            resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/redirect-with-host.html?host=${SAMPLE_HOST}`, {
               redirect: 'manual',
             });
             assert.strictEqual(resp.status, 301);
             assert.strictEqual(resp.headers.get('Location'), '/index.html');
 
-            resp = await fetch(`http://localhost:${cmd.project.server.port}/redirect-with-external-host.html?host=${SAMPLE_HOST}`, {
+            resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/redirect-with-external-host.html?host=${SAMPLE_HOST}`, {
               redirect: 'manual',
             });
             assert.strictEqual(resp.status, 301);
             assert.strictEqual(resp.headers.get('Location'), 'https://www.somewhereelse.com');
 
-            resp = await fetch(`http://localhost:${cmd.project.server.port}/index-with-cookie.html?host=${SAMPLE_HOST}`);
+            resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/index-with-cookie.html?host=${SAMPLE_HOST}`);
             assert.strictEqual(resp.status, 200);
             ret = await resp.text();
             assert.strictEqual(ret.trim(), content.index);
             cookies = resp.headers.get('set-cookie');
             assert.equal(cookies, `hlx-proxyhost=${encodeURIComponent(SAMPLE_HOST)}; Path=/`);
 
-            resp = await fetch(`http://localhost:${cmd.project.server.port}/page-with-security.html?host=${SAMPLE_HOST}`);
+            resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/page-with-security.html?host=${SAMPLE_HOST}`);
             assert.strictEqual(resp.status, 200);
             assert.strictEqual(resp.headers.get('content-security-policy'), null);
             assert.strictEqual(resp.headers.get('x-frame-options'), null);
 
-            const js = await assertHttp(`http://localhost:${cmd.project.server.port}/tools/importer/import.js`, 200);
+            const js = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/tools/importer/import.js`, 200);
             assert.strictEqual(js.trim(), '// import.js code');
 
-            await assertHttp(`http://localhost:${cmd.project.server.port}/tools/not-found.txt`, 404);
+            await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/tools/not-found.txt`, 404);
           };
 
           await assertRequests();
@@ -460,12 +460,12 @@ describe('Integration test for import command with cache', function suite() {
     cmd
       .on('started', async () => {
         try {
-          let resp = await fetch(`http://localhost:${cmd.project.server.port}/some-post-url?host=${SAMPLE_HOST}`, { method: 'POST', body: '{"iteration": 1}' });
+          let resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/some-post-url?host=${SAMPLE_HOST}`, { method: 'POST', body: '{"iteration": 1}' });
           assert.strictEqual(resp.status, 200);
           let json = await resp.json();
           assert.strictEqual(json.postIteration, 'num-1');
 
-          resp = await fetch(`http://localhost:${cmd.project.server.port}/some-post-url?host=${SAMPLE_HOST}`, { method: 'POST', body: '{"iteration": 2}' });
+          resp = await fetch(`http://127.0.0.1:${cmd.project.server.port}/some-post-url?host=${SAMPLE_HOST}`, { method: 'POST', body: '{"iteration": 2}' });
           assert.strictEqual(resp.status, 200);
           json = await resp.json();
           assert.strictEqual(json.postIteration, 'num-2');
@@ -494,7 +494,7 @@ describe('Import command - importer ui', function suite() {
     await fse.copy(TEST_DIR, testDir);
 
     nock = new Nock();
-    nock.enableNetConnect(/localhost|github\.com/);
+    nock.enableNetConnect(/127.0.0.1|github\.com/);
   });
 
   afterEach(async () => {
@@ -521,7 +521,7 @@ describe('Import command - importer ui', function suite() {
       .on('started', async () => {
         try {
           assert.ok(await fse.pathExists(`${testDir}/tools/importer/helix-importer-ui/index.html`), 'helix-importer-ui project has been cloned');
-          await assertHttp(`http://localhost:${cmd.project.server.port}/tools/importer/helix-importer-ui/index.html`, 200);
+          await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/tools/importer/helix-importer-ui/index.html`, 200);
 
           await myDone();
         } catch (e) {

--- a/test/import-server-project.test.js
+++ b/test/import-server-project.test.js
@@ -13,24 +13,29 @@
 /* eslint-env mocha */
 import assert from 'assert';
 import path from 'path';
-import HelixImportProject from '../src/server/HelixImportProject.js';
+import { HelixImportProject } from '../src/server/HelixImportProject.js';
 
 const SPEC_ROOT = path.resolve(__rootdir, 'test', 'specs');
 
 describe('Helix Project', () => {
-  it('can set port', async () => {
+  it('can set port and bind address', async () => {
     const cwd = path.join(SPEC_ROOT, 'fixtures', 'import');
     const project = await new HelixImportProject()
       .withCwd(cwd)
       .withHttpPort(0)
+      .withBindAddr('*')
       .init();
 
     await project.start();
-    assert.equal(true, project.started);
-    assert.notEqual(project.server.port, 0);
-    assert.notEqual(project.server.port, 3000);
-    await project.stop();
-    assert.equal(false, project.started);
+    try {
+      assert.strictEqual(project.started, true);
+      assert.notStrictEqual(project.server.port, 0);
+      assert.notStrictEqual(project.server.port, 3000);
+      assert.strictEqual(project.server.addr, '0.0.0.0');
+    } finally {
+      await project.stop();
+    }
+    assert.strictEqual(project.started, false);
   });
 
   it('can start and stop local project', async () => {
@@ -41,8 +46,11 @@ describe('Helix Project', () => {
       .init();
 
     await project.start();
-    assert.equal(true, project.started);
-    await project.stop();
-    assert.equal(false, project.started);
+    try {
+      assert.strictEqual(project.started, true);
+    } finally {
+      await project.stop();
+    }
+    assert.strictEqual(project.started, false);
   });
 });

--- a/test/server-livereload.test.js
+++ b/test/server-livereload.test.js
@@ -18,7 +18,7 @@ import assert from 'assert';
 import fse from 'fs-extra';
 import path from 'path';
 import WebSocket from 'faye-websocket';
-import HelixProject from '../src/server/HelixProject.js';
+import { HelixProject } from '../src/server/HelixProject.js';
 import {
   assertHttp, createTestRoot, Nock, setupProject, wait,
 } from './utils.js';
@@ -32,7 +32,7 @@ describe('Helix Server with Livereload', () => {
 
   beforeEach(async () => {
     nock = new Nock();
-    nock.enableNetConnect(/localhost/);
+    nock.enableNetConnect(/127.0.0.1/);
     testRoot = await createTestRoot();
     CODESPACES_ORIGINAL = process.env.CODESPACES;
   });
@@ -58,7 +58,7 @@ describe('Helix Server with Livereload', () => {
     await project.init();
     try {
       await project.start();
-      await assertHttp(`http://localhost:${project.server.port}/__internal__/livereload.js`, 200, require.resolve('livereload-js/dist/livereload.js'));
+      await assertHttp(`http://127.0.0.1:${project.server.port}/__internal__/livereload.js`, 200, require.resolve('livereload-js/dist/livereload.js'));
     } finally {
       await project.stop();
     }
@@ -84,7 +84,7 @@ describe('Helix Server with Livereload', () => {
 
     try {
       await project.start();
-      await assertHttp(`http://localhost:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr.html', [{
+      await assertHttp(`http://127.0.0.1:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr.html', [{
         pattern: 'PORT',
         with: project.server.port,
       }]);
@@ -113,7 +113,7 @@ describe('Helix Server with Livereload', () => {
 
     try {
       await project.start();
-      await assertHttp(`http://localhost:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr_nohead.html', [{
+      await assertHttp(`http://127.0.0.1:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr_nohead.html', [{
         pattern: 'PORT',
         with: project.server.port,
       }]);
@@ -143,7 +143,7 @@ describe('Helix Server with Livereload', () => {
 
     try {
       await project.start();
-      await assertHttp(`http://localhost:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr_nohead_codespaces.html');
+      await assertHttp(`http://127.0.0.1:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr_nohead_codespaces.html');
     } finally {
       await project.stop();
     }
@@ -169,7 +169,7 @@ describe('Helix Server with Livereload', () => {
 
     try {
       await project.start();
-      await assertHttp(`http://localhost:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr_nobody.html', [{
+      await assertHttp(`http://127.0.0.1:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr_nobody.html', [{
         pattern: 'PORT',
         with: project.server.port,
       }]);
@@ -198,7 +198,7 @@ describe('Helix Server with Livereload', () => {
     await project.init();
     try {
       await project.start();
-      await assertHttp(`http://localhost:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr_nohtml.html');
+      await assertHttp(`http://127.0.0.1:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr_nohtml.html');
     } finally {
       await project.stop();
     }
@@ -223,12 +223,12 @@ describe('Helix Server with Livereload', () => {
     try {
       await project.start();
 
-      await assertHttp(`http://localhost:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr.html', [{
+      await assertHttp(`http://127.0.0.1:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr.html', [{
         pattern: 'PORT',
         with: project.server.port,
       }]);
 
-      const ws = new WebSocket.Client(`ws://localhost:${project.server.port}/`);
+      const ws = new WebSocket.Client(`ws://127.0.0.1:${project.server.port}/`);
       let wsReloadData = null;
       let wsHelloData = null;
       const wsOpenPromise = new Promise((resolve, reject) => {
@@ -239,7 +239,7 @@ describe('Helix Server with Livereload', () => {
           ws.send(JSON.stringify({
             command: 'info',
             plugins: [],
-            url: `http://localhost:${project.server.port}/styles.css`,
+            url: `http://127.0.0.1:${project.server.port}/styles.css`,
           }));
           resolve();
         });
@@ -262,7 +262,7 @@ describe('Helix Server with Livereload', () => {
         ws.on('close', resolve);
       });
 
-      await assertHttp(`http://localhost:${project.server.port}/styles.css`, 200, 'expected_styles.css');
+      await assertHttp(`http://127.0.0.1:${project.server.port}/styles.css`, 200, 'expected_styles.css');
       await wsOpenPromise;
       await fse.copy(path.resolve(cwd, 'styles-modified.css'), path.resolve(cwd, 'styles.css'));
       await wait(500);
@@ -309,12 +309,12 @@ describe('Helix Server with Livereload', () => {
 
     try {
       await project.start();
-      await assertHttp(`http://localhost:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr.html', [{
+      await assertHttp(`http://127.0.0.1:${project.server.port}/live/index.html`, 200, 'expected_index_w_lr.html', [{
         pattern: 'PORT',
         with: project.server.port,
       }]);
 
-      const ws = new WebSocket.Client(`ws://localhost:${project.server.port}/`);
+      const ws = new WebSocket.Client(`ws://127.0.0.1:${project.server.port}/`);
       let wsAlertData = null;
       let wsHelloData = null;
       const wsOpenPromise = new Promise((resolve, reject) => {
@@ -325,7 +325,7 @@ describe('Helix Server with Livereload', () => {
           ws.send(JSON.stringify({
             command: 'info',
             plugins: [],
-            url: `http://localhost:${project.server.port}/index.html`,
+            url: `http://127.0.0.1:${project.server.port}/index.html`,
           }));
           resolve();
         });
@@ -349,7 +349,7 @@ describe('Helix Server with Livereload', () => {
       });
 
       await wsOpenPromise;
-      project._liveReload.alert('hello alert');
+      project.liveReload.alert('hello alert');
       await wait(500);
       ws.close();
       // ensure socket properly closes

--- a/test/server-project.test.js
+++ b/test/server-project.test.js
@@ -13,7 +13,7 @@
 /* eslint-env mocha */
 import assert from 'assert';
 import path from 'path';
-import HelixProject from '../src/server/HelixProject.js';
+import { HelixProject } from '../src/server/HelixProject.js';
 
 const SPEC_ROOT = path.resolve(__rootdir, 'test', 'specs');
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -16,7 +16,7 @@ import os from 'os';
 import assert from 'assert';
 import fse from 'fs-extra';
 import path from 'path';
-import HelixProject from '../src/server/HelixProject.js';
+import { HelixProject } from '../src/server/HelixProject.js';
 import {
   Nock, assertHttp, createTestRoot, setupProject,
 } from './utils.js';
@@ -28,7 +28,7 @@ describe('Helix Server', () => {
 
   beforeEach(async () => {
     nock = new Nock();
-    nock.enableNetConnect(/localhost/);
+    nock.enableNetConnect(/127.0.0.1/);
     testRoot = await createTestRoot();
   });
 
@@ -111,7 +111,7 @@ describe('Helix Server', () => {
     await project.init();
     try {
       await project.start();
-      await assertHttp(`http://localhost:${project.server.port}/welcome.txt`, 200, 'expected_welcome.txt');
+      await assertHttp(`http://127.0.0.1:${project.server.port}/welcome.txt`, 200, 'expected_welcome.txt');
     } finally {
       await project.stop();
     }
@@ -125,7 +125,7 @@ describe('Helix Server', () => {
     await project.init();
     try {
       await project.start();
-      await assertHttp(`http://localhost:${project.server.port}/.kill`, 200, 'expected_goodbye.txt');
+      await assertHttp(`http://127.0.0.1:${project.server.port}/.kill`, 200, 'expected_goodbye.txt');
     } finally {
       assert.ok(!project.server.isStarted());
       await project.stop();
@@ -149,7 +149,7 @@ describe('Helix Server', () => {
 
     try {
       await project.start();
-      await assertHttp(`http://localhost:${project.server.port}/notfound.css`, 404);
+      await assertHttp(`http://127.0.0.1:${project.server.port}/notfound.css`, 404);
     } finally {
       await project.stop();
     }
@@ -173,7 +173,7 @@ describe('Helix Server', () => {
 
     try {
       await project.start();
-      const resp = await fetch(`http://localhost:${project.server.port}/local.html`, {
+      const resp = await fetch(`http://127.0.0.1:${project.server.port}/local.html`, {
         cache: 'no-store',
       });
       const ret = await resp.text();
@@ -208,7 +208,7 @@ describe('Helix Server', () => {
 
     try {
       await project.start();
-      const resp = await fetch(`http://localhost:${project.server.port}/readme.html`, {
+      const resp = await fetch(`http://127.0.0.1:${project.server.port}/readme.html`, {
         cache: 'no-store',
       });
       const ret = await resp.text();
@@ -244,7 +244,7 @@ describe('Helix Server', () => {
 
     try {
       await project.start();
-      const resp = await fetch(`http://localhost:${project.server.port}/readme.html`, {
+      const resp = await fetch(`http://127.0.0.1:${project.server.port}/readme.html`, {
         cache: 'no-store',
       });
       const ret = await resp.text();
@@ -283,7 +283,7 @@ describe('Helix Server', () => {
 
     try {
       await project.start();
-      const resp = await fetch(`http://localhost:${project.server.port}/subfolder/query-index.json?sheet=foo&limit=20`, {
+      const resp = await fetch(`http://127.0.0.1:${project.server.port}/subfolder/query-index.json?sheet=foo&limit=20`, {
         cache: 'no-store',
       });
       assert.strictEqual(resp.status, 200);

--- a/test/up-cli.test.js
+++ b/test/up-cli.test.js
@@ -39,6 +39,7 @@ describe('hlx up', () => {
     mockUp.withTLS.returnsThis();
     mockUp.withLiveReload.returnsThis();
     mockUp.withHttpPort.returnsThis();
+    mockUp.withBindAddr.returnsThis();
     mockUp.withUrl.returnsThis();
     mockUp.withPrintIndex.returnsThis();
     mockUp.withKill.returnsThis();
@@ -68,6 +69,7 @@ describe('hlx up', () => {
     sinon.assert.calledWith(mockUp.withOpen, 'false');
     sinon.assert.calledWith(mockUp.withLiveReload, false);
     sinon.assert.calledWith(mockUp.withHttpPort, 1234);
+    sinon.assert.calledWith(mockUp.withBindAddr, '*');
     sinon.assert.calledOnce(mockUp.run);
   });
 
@@ -97,6 +99,12 @@ describe('hlx up', () => {
   it('hlx up can specify port number to run development server on', async () => {
     await cli.run(['up', '--port', '3210']);
     sinon.assert.calledWith(mockUp.withHttpPort, 3210);
+    sinon.assert.calledOnce(mockUp.run);
+  });
+
+  it('hlx up can specify bind address to run development server on', async () => {
+    await cli.run(['up', '--addr', '192.168.1.7']);
+    sinon.assert.calledWith(mockUp.withBindAddr, '192.168.1.7');
     sinon.assert.calledOnce(mockUp.run);
   });
 

--- a/test/up-cmd.test.js
+++ b/test/up-cmd.test.js
@@ -31,7 +31,7 @@ describe('Integration test for up command with helix pages', function suite() {
     testRoot = await createTestRoot();
     testDir = path.resolve(testRoot, 'project');
     nock = new Nock();
-    nock.enableNetConnect(/localhost/);
+    nock.enableNetConnect(/127.0.0.1/);
     await fse.copy(TEST_DIR, testDir);
   });
 
@@ -67,11 +67,11 @@ describe('Integration test for up command with helix pages', function suite() {
     cmd
       .on('started', async () => {
         try {
-          let ret = await assertHttp(`http://localhost:${cmd.project.server.port}/index.html`, 200);
+          let ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/index.html`, 200);
           assert.strictEqual(ret.trim(), '## Welcome');
-          ret = await assertHttp(`http://localhost:${cmd.project.server.port}/local.txt`, 200);
+          ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/local.txt`, 200);
           assert.strictEqual(ret.trim(), 'Hello, world.');
-          await assertHttp(`http://localhost:${cmd.project.server.port}/not-found.txt`, 404);
+          await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/not-found.txt`, 404);
           await myDone();
         } catch (e) {
           await myDone(e);
@@ -111,11 +111,11 @@ describe('Integration test for up command with helix pages', function suite() {
     cmd
       .on('started', async () => {
         try {
-          let ret = await assertHttp(`http://localhost:${cmd.project.server.port}/index.html`, 200);
+          let ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/index.html`, 200);
           assert.strictEqual(ret.trim(), '## Welcome');
-          ret = await assertHttp(`http://localhost:${cmd.project.server.port}/local.txt`, 200);
+          ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/local.txt`, 200);
           assert.strictEqual(ret.trim(), 'Hello, world.');
-          await assertHttp(`http://localhost:${cmd.project.server.port}/not-found.txt`, 404);
+          await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/not-found.txt`, 404);
           await myDone();
         } catch (e) {
           await myDone(e);
@@ -157,11 +157,11 @@ describe('Integration test for up command with helix pages', function suite() {
     cmd
       .on('started', async () => {
         try {
-          let ret = await assertHttp(`http://localhost:${cmd.project.server.port}/index.html`, 200);
+          let ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/index.html`, 200);
           assert.strictEqual(ret.trim(), '## Welcome');
-          ret = await assertHttp(`http://localhost:${cmd.project.server.port}/local.txt`, 200);
+          ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/local.txt`, 200);
           assert.strictEqual(ret.trim(), 'Hello, world.');
-          await assertHttp(`http://localhost:${cmd.project.server.port}/not-found.txt`, 404);
+          await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/not-found.txt`, 404);
           await myDone();
         } catch (e) {
           await myDone(e);
@@ -210,11 +210,11 @@ describe('Integration test for up command with helix pages', function suite() {
     cmd
       .on('started', async () => {
         try {
-          let ret = await assertHttp(`http://localhost:${cmd.project.server.port}/index.html`, 200);
+          let ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/index.html`, 200);
           assert.strictEqual(ret.trim(), '## Welcome');
-          ret = await assertHttp(`http://localhost:${cmd.project.server.port}/local.txt`, 200);
+          ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/local.txt`, 200);
           assert.strictEqual(ret.trim(), 'Hello, world.');
-          await assertHttp(`http://localhost:${cmd.project.server.port}/not-found.txt`, 404);
+          await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/not-found.txt`, 404);
           // now switch to a new branch
           switchBranch(testDir, 'new-branch');
           // wait 5 seconds for the git branch to be detected
@@ -260,11 +260,11 @@ describe('Integration test for up command with helix pages', function suite() {
     let timer;
     cmd
       .on('started', async () => {
-        let ret = await assertHttp(`http://localhost:${cmd.project.server.port}/index.html`, 200);
+        let ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/index.html`, 200);
         assert.strictEqual(ret.trim(), '## Welcome');
-        ret = await assertHttp(`http://localhost:${cmd.project.server.port}/local.txt`, 200);
+        ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/local.txt`, 200);
         assert.strictEqual(ret.trim(), 'Hello, world.');
-        await assertHttp(`http://localhost:${cmd.project.server.port}/not-found.txt`, 404);
+        await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/not-found.txt`, 404);
         // now switch to a new branch
         switchBranch(testDir, 'new-and-totally-unreasonably-long-in-fact-too-long-branch');
         // wait 5 seconds for the git branch to be detected
@@ -336,25 +336,25 @@ describe('Integration test for up command with cache', function suite() {
       .get('/head.html')
       .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
 
-    nock.enableNetConnect(/localhost/);
+    nock.enableNetConnect(/127.0.0.1/);
 
     cmd
       .on('started', async () => {
         try {
           const assertRequests = async () => {
-            let ret = await assertHttp(`http://localhost:${cmd.project.server.port}/index.html`, 200);
+            let ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/index.html`, 200);
             assert.strictEqual(ret.trim(), content.index);
-            ret = await assertHttp(`http://localhost:${cmd.project.server.port}/`, 200);
+            ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/`, 200);
             assert.strictEqual(ret.trim(), content.index);
-            ret = await assertHttp(`http://localhost:${cmd.project.server.port}/folder/page.html?foo=bar&baz=qux`, 200);
+            ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/folder/page.html?foo=bar&baz=qux`, 200);
             assert.strictEqual(ret.trim(), content.page1);
-            ret = await assertHttp(`http://localhost:${cmd.project.server.port}/folder/page.html?foo=bar&baz=othervalue`, 200);
+            ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/folder/page.html?foo=bar&baz=othervalue`, 200);
             assert.strictEqual(ret.trim(), content.page2);
-            await assertHttp(`http://localhost:${cmd.project.server.port}/not-found.txt`, 404);
-            ret = await assertHttp(`http://localhost:${cmd.project.server.port}/page.plain.html`, 200);
+            await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/not-found.txt`, 404);
+            ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/page.plain.html`, 200);
             assert.strictEqual(ret.trim(), content.plain);
 
-            ret = await assertHttp(`http://localhost:${cmd.project.server.port}/local.txt`, 200);
+            ret = await assertHttp(`http://127.0.0.1:${cmd.project.server.port}/local.txt`, 200);
             assert.strictEqual(ret.trim(), 'Hello, world.');
           };
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -12,6 +12,7 @@
 /* eslint-env mocha */
 import assert from 'assert';
 import path from 'path';
+import net from 'net';
 import shell from 'shelljs';
 import crypto from 'crypto';
 import fse from 'fs-extra';
@@ -99,6 +100,27 @@ export async function setupProject(srcDir, root) {
 export async function wait(time) {
   return new Promise((resolve) => {
     setTimeout(resolve, time);
+  });
+}
+
+export async function rawGet(host, port, pathname) {
+  return new Promise((resolve, reject) => {
+    const response = [];
+    const client = net.createConnection({
+      host,
+      port,
+    }, () => {
+      client.write(`GET ${pathname}\r\n\r\n`);
+    });
+    client.on('data', (data) => {
+      response.push(data);
+    });
+    client.on('end', () => {
+      resolve(Buffer.concat(response));
+    });
+    client.on('error', (err) => {
+      reject(err);
+    });
   });
 }
 


### PR DESCRIPTION
- refactored `HelixServer` and `ImportServer` so that they both extend from a common `BaseServer`
- refactored `HelixProject` and `ImportProject` so that they both extend from a common `BaseProject`
- refactored `UpCommand` and `ImportCommand` so that they both extend from a common `AbstractServerCommand`
- ensured that `/.kill` requests properly terminate the process (for `up` and `import`)

- fixes #2150 
- fixes #2149 
- fixes #2153
