### PR TITLE
fix: more AEM branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Helix/AEM Command Line Interface (`aem` or `aem`)
+# Helix/AEM Command Line Interface (`aem`)
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub issues](https://img.shields.io/github/issues/adobe/helix-cli.svg)](https://github.com/adobe/helix-cli/issues)
 [![LGTM Code Quality Grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/adobe/helix-cli.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/adobe/helix-cli)
 
-The AEM Command Line Interface allows web developers to create, develop, and deploy digital experiences using Adobe Experience Manager Sites 'Edge Delivery Services' f.k.a 'Project Franklin' f.k.a 'Project Helix'
+The AEM Command Line Interface allows web developers to create, develop, and deploy digital experiences using the Adobe Experience Manager Sites feature Edge Delivery Services. Some of this functionality was known as Franklin or Project Helix before.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ aem --help
 Usage: aem <command> [options]
 
 Commands:
-  aem up  Run a Helix development server
+  aem up  Run a AEM development server
 
 Options:
   --version                Show version number                         [boolean]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Helix/AEM Command Line Interface (`hlx` or `aem`)
+# Helix/AEM Command Line Interface (`aem` or `aem`)
 
 ## Status
 
@@ -8,25 +8,24 @@
 [![GitHub issues](https://img.shields.io/github/issues/adobe/helix-cli.svg)](https://github.com/adobe/helix-cli/issues)
 [![LGTM Code Quality Grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/adobe/helix-cli.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/adobe/helix-cli)
 
-The Helix Command Line Interface allows web developers to create, develop, and deploy digital experiences using Adobe Experience Manager Sites 'Edge Delivery Services' f.k.a 'Project Helix'
+The AEM Command Line Interface allows web developers to create, develop, and deploy digital experiences using Adobe Experience Manager Sites 'Edge Delivery Services' f.k.a 'Project Franklin' f.k.a 'Project Helix'
 
 ## Installation
 
-Install `hlx` or `aem` as a global command. You need Node 12.11 or newer.
+Install `aem` as a global command. You need Node 12.11 or newer.
 
 ```bash
-$ npm install -g @adobe/helix-cli
+$ npm install -g @adobe/aem-cli
 ```
 
 ## Quick Start
-You can interchange `hlx` and `aem` in the examples listed below.
 
 ```
-$ hlx --help
-Usage: hlx <command> [options]
+$ aem --help
+Usage: aem <command> [options]
 
 Commands:
-  hlx up  Run a Helix development server
+  aem up  Run a Helix development server
 
 Options:
   --version                Show version number                         [boolean]
@@ -47,7 +46,7 @@ for more information, find our manual at https://github.com/adobe/helix-cli
 
 ```
 $ cd <my-cool-project>
-$ hlx up
+$ aem up
 ```
 
 ### automatically open the browser
@@ -66,23 +65,24 @@ $ openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -out server.c
 
 this will create 2 files: `server.crt` and `server.key`
 
-2. start hlx with tls support
+2. start aem with tls support
 
 ```
-$ hlx up --tls-cert server.crt --tls-key server.key
-    ____              __    ___   v14.21.4
-   / __/______ ____  / /__ / (_)__
-  / _// __/ _ `/ _ \/  '_// / / _ \
- /_/ /_/  \_,_/_//_/_/\_\/_/_/_//_/
+$ aem up --tls-cert server.crt --tls-key server.key
+    ___   ______  ___  ____   __         ___      ___
+   / _ | / __/  |/  / / __/__/ /__ ____ / _ \___ / (_)  _____ ______ __
+  / __ |/ _// /|_/ / / _// _  / _ `/ -_) // / -_) / / |/ / -_) __/ // /
+ /_/ |_/___/_/  /_/ /___/\_,_/\_, /\__/____/\__/_/_/|___/\__/_/  \_, /
+                             /___/                      v14.26.0 ___/
 
-info: Starting Franklin dev server v14.21.4
-info: Local Franklin dev server up and running: https://localhost:3000/
+info: Starting AEM dev server v14.26.0
+info: Local AEM dev server up and running: https://localhost:3000/
 ```
 
 3. (optional) Add arguments to .env file:
 
 ```
-$ echo -e "HLX_TLS_CERT=server.crt\nHLX_TLS_KEY=server.key" >> .env
+$ echo -e "AEM_TLS_CERT=server.crt\nAEM_TLS_KEY=server.key" >> .env
 ```
 
 ### environment
@@ -94,9 +94,9 @@ example:
 
 `.env`
 ```dotenv
-HLX_OPEN=/products
-HLX_PORT=8080
-HLX_PAGES_URL=https://stage.myproject.com
+AEM_OPEN=/products
+AEM_PORT=8080
+AEM_PAGES_URL=https://stage.myproject.com
 ```
 
 #### HTTP Proxy
@@ -123,25 +123,25 @@ If present, `ALL_PROXY` is used as fallback if there is no other match.
 
 | option | variable | default | description |
 |--------|----------|---------|-------------|
-| `--log-file` | `HLX_LOG_FILE` | `-` | Log file. use `-` to log to stdout |
-| `--log-level` | `HLX_LOG_LEVEL` | `info` | Log level |
+| `--log-file` | `AEM_LOG_FILE` | `-` | Log file. use `-` to log to stdout |
+| `--log-level` | `AEM_LOG_LEVEL` | `info` | Log level |
 
 #### Up command
 
 | option            | variable            | default     | description                                                 |
 |-------------------|---------------------|-------------|-------------------------------------------------------------|
-| `--port`          | `HLX_PORT`          | `3000`      | Development server port                                     |
-| `--addr`          | `HLX_ADDR`          | `127.0.0.1` | Development server bind address                             |
-| `--livereload`    | `HLX_LIVERELOAD`    | `true`      | Enable automatic reloading of modified sources in browser.  |
-| `--no-livereload` | `HLX_NO_LIVERELOAD` | `false`     | Disable live-reload.                                        |
-| `--open`          | `HLX_OPEN`          | `/`         | Open a browser window at specified path after server start. |
-| `--no-open`       | `HLX_NO_OPEN`       | `false`     | Disable automatic opening of browser window.                |
-| `--tls-key`       | `HLX_TLS_KEY`       | undefined   | Path to .key file (for enabling TLS)                        |
-| `--tls-cert`      | `HLX_TLS_CERT`      | undefined   | Path to .pem file (for enabling TLS)                        |
+| `--port`          | `AEM_PORT`          | `3000`      | Development server port                                     |
+| `--addr`          | `AEM_ADDR`          | `127.0.0.1` | Development server bind address                             |
+| `--livereload`    | `AEM_LIVERELOAD`    | `true`      | Enable automatic reloading of modified sources in browser.  |
+| `--no-livereload` | `AEM_NO_LIVERELOAD` | `false`     | Disable live-reload.                                        |
+| `--open`          | `AEM_OPEN`          | `/`         | Open a browser window at specified path after server start. |
+| `--no-open`       | `AEM_NO_OPEN`       | `false`     | Disable automatic opening of browser window.                |
+| `--tls-key`       | `AEM_TLS_KEY`       | undefined   | Path to .key file (for enabling TLS)                        |
+| `--tls-cert`      | `AEM_TLS_CERT`      | undefined   | Path to .pem file (for enabling TLS)                        |
 
 # Developing Helix CLI
 
 ## Testing
 
 You can use `npm run check` to run the tests and check whether your code adheres
-to the helix-cli coding style.
+to the aem-cli coding style.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@adobe/helix-cli",
+  "name": "@adobe/aem-cli",
   "version": "14.26.0",
-  "description": "Project Helix CLI",
+  "description": "AEM CLI",
   "main": "index.js",
   "type": "module",
   "bin": {

--- a/src/hack.cmd.js
+++ b/src/hack.cmd.js
@@ -42,7 +42,7 @@ export default class HackCommand extends AbstractCommand {
       await opn(url);
     } else {
       // eslint-disable-next-line no-console
-      this.log.info(chalk`Check out the Franklin Hackathon at {blue ${url}}`);
+      this.log.info(chalk`Check out the AEM Hackathon at {blue ${url}}`);
     }
   }
 }

--- a/src/import.cmd.js
+++ b/src/import.cmd.js
@@ -55,7 +55,7 @@ export default class ImportCommand extends AbstractServerCommand {
       });
       this.log.info(`AEM Importer UI is ready. v${await getUIVersion()}`);
     } else {
-      this.log.info('Fetching latest version of the AEM Import UI...');
+      this.log.info('Fetching latest version of the AEM Importer UI...');
       // clone the ui project
       await git.pull({
         fs: fse,

--- a/src/import.cmd.js
+++ b/src/import.cmd.js
@@ -39,9 +39,10 @@ export default class ImportCommand extends AbstractServerCommand {
     await fse.ensureDir(importerFolder);
     const uiProjectName = path.basename(this._uiRepo, '.git');
     const uiFolder = path.join(importerFolder, uiProjectName);
+    const getUIVersion = async () => ((await fse.readJson(path.resolve(uiFolder, 'package.json'))).version);
     const exists = await fse.pathExists(uiFolder);
     if (!exists) {
-      this.log.info('Franklin Importer UI needs to be installed.');
+      this.log.info('AEM Importer UI needs to be installed.');
       this.log.info(`Cloning ${this._uiRepo} in ${importerFolder}.`);
       // clone the ui project
       await git.clone({
@@ -52,9 +53,9 @@ export default class ImportCommand extends AbstractServerCommand {
         depth: 1,
         singleBranch: true,
       });
-      this.log.info('Franklin Importer UI is ready.');
+      this.log.info(`AEM Importer UI is ready. v${await getUIVersion()}`);
     } else {
-      this.log.info('Fetching latest version of the Franklin Import UI.');
+      this.log.info('Fetching latest version of the AEM Import UI...');
       // clone the ui project
       await git.pull({
         fs: fse,
@@ -67,7 +68,7 @@ export default class ImportCommand extends AbstractServerCommand {
           name: 'hlx import',
         },
       });
-      this.log.info('Franklin Importer UI is now up-to-date.');
+      this.log.info(`AEM Importer UI is up-to-date. v${await getUIVersion()}`);
     }
   }
 
@@ -79,12 +80,11 @@ export default class ImportCommand extends AbstractServerCommand {
       .withCwd(this.directory)
       .withLogger(this._logger)
       .withKill(this._kill);
-
-    this.log.info(chalk`{yellow     ____              __    ___      ____                    __}`);
-    this.log.info(chalk`{yellow    / __/______ ____  / /__ / (_)__  /  _/_ _  ___  ___  ____/ /_}`);
-    this.log.info(chalk`{yellow   / _// __/ _ \`/ _ \\/  '_// / / _ \\_/ //  ' \\/ _ \\/ _ \\/ __/ __/}`);
-    this.log.info(chalk`{yellow  /_/ /_/  \\_,_/_//_/_/\\_\\/_/_/_//_/___/_/_/_/ .__/\\___/_/  \\__/}`);
-    this.log.info(chalk`{yellow                                            /_/  v${pkgJson.version}}`);
+    this.log.info(chalk`{yellow    ___   ______  ___  ____                    __ }`);
+    this.log.info(chalk`{yellow   / _ | / __/  |/  / /  _/_ _  ___  ___  ____/ /____ ____}`);
+    this.log.info(chalk`{yellow  / __ |/ _// /|_/ / _/ //  ' \\/ _ \\/ _ \\/ __/ __/ -_) __/}`);
+    this.log.info(chalk`{yellow /_/ |_/___/_/  /_/ /___/_/_/_/ .__/\\___/_/  \\__/\\__/_/}`);
+    this.log.info(chalk`{yellow                             /_/  v${pkgJson.version}}`);
     this.log.info('');
 
     await this.initSeverOptions();
@@ -96,7 +96,7 @@ export default class ImportCommand extends AbstractServerCommand {
     try {
       await this._project.init();
     } catch (e) {
-      throw Error(`Unable to start Franklin: ${e.message}`);
+      throw Error(`Unable to start AEM: ${e.message}`);
     }
   }
 }

--- a/src/import.js
+++ b/src/import.js
@@ -79,7 +79,7 @@ export default function up() {
           describe: 'Path to local folder to cache the responses',
           type: 'string',
         })
-        .group(['open', 'no-open', 'cache', 'ui-repo', 'skip-ui'], 'AEM Import Options')
+        .group(['open', 'no-open', 'cache', 'ui-repo', 'skip-ui'], 'AEM Importer Options')
 
         .help();
     },

--- a/src/import.js
+++ b/src/import.js
@@ -98,7 +98,7 @@ export default function up() {
         .withBindAddr(argv.addr)
         // only open  browser window when executable is `aem`
         // this prevents the window to be opened during integration tests
-        .withOpen(path.basename(argv.$0) === 'hlx' || path.basename(argv.$0) === 'aem' ? argv.open : false)
+        .withOpen(path.basename(argv.$0) === 'aem' ? argv.open : false)
         .withTLS(argv.tlsKey, argv.tlsCert)
         .withKill(argv.stopOther)
         .withCache(argv.cache)

--- a/src/import.js
+++ b/src/import.js
@@ -19,7 +19,7 @@ export default function up() {
       executor = value;
     },
     command: 'import',
-    description: 'Run the Franklin import server',
+    description: 'Run the AEM import server',
     builder: (yargs) => {
       yargs
         .option('open', {
@@ -29,13 +29,13 @@ export default function up() {
         })
         .option('ui-repo', {
           alias: 'uiRepo',
-          describe: 'Git repository for the Franklin Importer UI',
+          describe: 'Git repository for the AEM Importer UI',
           type: 'string',
           default: 'https://github.com/adobe/helix-importer-ui',
         })
         .option('skip-ui', {
           alias: 'skipUI',
-          describe: 'Do not install the Franklin Importer UI',
+          describe: 'Do not install the AEM Importer UI',
           type: 'boolean',
           default: false,
         })
@@ -58,7 +58,7 @@ export default function up() {
         })
         .option('stop-other', {
           alias: 'stopOther',
-          describe: 'Stop other Franklin CLI running on the above port',
+          describe: 'Stop other AEM CLI running on the above port',
           type: 'boolean',
           default: true,
         })
@@ -79,7 +79,7 @@ export default function up() {
           describe: 'Path to local folder to cache the responses',
           type: 'string',
         })
-        .group(['open', 'no-open', 'cache', 'ui-repo', 'skip-ui'], 'Franklin Import Options')
+        .group(['open', 'no-open', 'cache', 'ui-repo', 'skip-ui'], 'AEM Import Options')
 
         .help();
     },
@@ -96,9 +96,9 @@ export default function up() {
       await executor
         .withHttpPort(argv.port)
         .withBindAddr(argv.addr)
-        // only open  browser window when executable is `hlx`
+        // only open  browser window when executable is `aem`
         // this prevents the window to be opened during integration tests
-        .withOpen(path.basename(argv.$0) === 'hlx' ? argv.open : false)
+        .withOpen(path.basename(argv.$0) === 'hlx' || path.basename(argv.$0) === 'aem' ? argv.open : false)
         .withTLS(argv.tlsKey, argv.tlsCert)
         .withKill(argv.stopOther)
         .withCache(argv.cache)

--- a/src/server/BaseServer.js
+++ b/src/server/BaseServer.js
@@ -137,7 +137,7 @@ export class BaseServer extends EventEmitter {
         throw new Error(`Port ${this._port} already in use by another process.`);
       }
     }
-    log.info(`Starting Franklin dev server v${packageJson.version}`);
+    log.info(`Starting AEM dev server v${packageJson.version}`);
     await new Promise((resolve, reject) => {
       const listenCb = (err) => {
         if (err) {
@@ -145,7 +145,7 @@ export class BaseServer extends EventEmitter {
         }
         this._port = this._server.address().port;
         this._addr = this._server.address().address;
-        log.info(`Local Franklin dev server up and running: ${this.scheme}://${this.hostname}:${this.port}/`);
+        log.info(`Local AEM dev server up and running: ${this.scheme}://${this.hostname}:${this.port}/`);
         if (this._project.proxyUrl) {
           log.info(`Enabled reverse proxy to ${this._project.proxyUrl}`);
         }
@@ -186,7 +186,7 @@ export class BaseServer extends EventEmitter {
     this._server = null;
     this.emit('stopping');
     await new Promise((resolve, reject) => {
-      this.log.debug('Stopping Franklin dev server..');
+      this.log.debug('Stopping AEM dev server..');
       for (const socket of this._sockets) {
         socket.destroy();
         this._sockets.delete(socket);
@@ -195,7 +195,7 @@ export class BaseServer extends EventEmitter {
         if (err) {
           reject(new Error(`Error while stopping http server: ${err}`));
         }
-        this.log.info('Franklin dev server stopped.');
+        this.log.info('AEM dev server stopped.');
         resolve();
       });
     });

--- a/src/server/HelixImportProject.js
+++ b/src/server/HelixImportProject.js
@@ -18,13 +18,13 @@ export class HelixImportProject extends BaseProject {
   }
 
   async start() {
-    this.log.debug('Launching Franklin import server for importing content...');
+    this.log.debug('Launching AEM import server for importing content...');
     await super.start();
     return this;
   }
 
   async doStop() {
-    this.log.debug('Stopping Franklin import server..');
+    this.log.debug('Stopping AEM import server..');
     await super.doStop();
   }
 }

--- a/src/server/HelixImportServer.js
+++ b/src/server/HelixImportServer.js
@@ -182,8 +182,8 @@ export class HelixImportServer extends BaseServer {
       // codecov:ignore:start
       /* c8 ignore start */
       } catch (err) {
-        log.error(`Failed to proxy Franklin request ${ctx.path}: ${err.message}`);
-        res.status(502).send(`Failed to proxy Franklin request: ${err.message}`);
+        log.error(`Failed to proxy AEM request ${ctx.path}: ${err.message}`);
+        res.status(502).send(`Failed to proxy AEM request: ${err.message}`);
       }
       // codecov:ignore:end
       /* c8 ignore end */

--- a/src/server/HelixProject.js
+++ b/src/server/HelixProject.js
@@ -109,7 +109,7 @@ export class HelixProject extends BaseProject {
   }
 
   async start() {
-    this.log.debug('Launching Franklin dev server...');
+    this.log.debug('Launching AEM dev server...');
     await super.start();
     await this.initHeadHtml();
     await this.init404Html();
@@ -120,7 +120,7 @@ export class HelixProject extends BaseProject {
   }
 
   async doStop() {
-    this.log.debug('Stopping Franklin dev server...');
+    this.log.debug('Stopping AEM dev server...');
     await super.doStop();
     if (this._indexer) {
       await this._indexer.close();

--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -92,8 +92,8 @@ export class HelixServer extends BaseServer {
         file404html: this._project.file404html,
       });
     } catch (err) {
-      log.error(`Failed to proxy Franklin request ${ctx.path}: ${err.message}`);
-      res.status(502).send(`Failed to proxy Franklin request: ${err.message}`);
+      log.error(`Failed to proxy AEM request ${ctx.path}: ${err.message}`);
+      res.status(502).send(`Failed to proxy AEM request: ${err.message}`);
     }
 
     this.emit('request', req, res, ctx);

--- a/src/server/Indexer.js
+++ b/src/server/Indexer.js
@@ -76,7 +76,7 @@ export default class Indexer {
       log.error(`Error in helix-query.yaml: ${e.message}`);
     }
     if (this._printIndex && this._index.indices.length === 0) {
-      log.warn(chalk`Franklin CLI started with {gray --print-index} but no valid {gray helix-query.yaml} found.`);
+      log.warn(chalk`AEM CLI started with {gray --print-index} but no valid {gray helix-query.yaml} found.`);
     }
   }
 

--- a/src/server/LiveReload.js
+++ b/src/server/LiveReload.js
@@ -66,7 +66,7 @@ class ClientConnection extends EventEmitter {
       protocols: [
         'http://livereload.com/protocols/official-7',
       ],
-      serverName: 'franklin-simulator',
+      serverName: 'aem-simulator',
     });
   }
 

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -66,12 +66,10 @@ export default class UpCommand extends AbstractServerCommand {
       .withLogger(this._logger)
       .withKill(this._kill)
       .withPrintIndex(this._printIndex);
-    const version = `v${pkgJson.version}`;
-    this.log.info(chalk`{yellow     ___   ______  ___  ____   __         ___      ___}`);
-    this.log.info(chalk`{yellow    / _ | / __/  |/  / / __/__/ /__ ____ / _ \\___ / (_)  _____ ______ __}`);
-    this.log.info(chalk`{yellow   / __ |/ _// /|_/ / / _// _  / _ \`/ -_) // / -_) / / |/ / -_) __/ // /}`);
-    this.log.info(chalk`{yellow  /_/ |_/___/_/  /_/ /___/\\_,_/\\_, /\\__/____/\\__/_/_/|___/\\__/_/  \\_, /}`);
-    this.log.info(chalk`{yellow                              /___/    ${version.padStart(26, ' ')} ___/}`);
+    this.log.info(chalk`{yellow     ___   ______  ___  _____            __     __ ${pkgJson.version}}`);
+    this.log.info(chalk`{yellow    / _ | / __/  |/  / / __(_)_ _  __ __/ /__ _/ /____  ____}`);
+    this.log.info(chalk`{yellow   / __ |/ _// /|_/ / _\\ \\/ /  ' \\/ // / / _ \`/ __/ _ \\/ __/}`);
+    this.log.info(chalk`{yellow  /_/ |_/___/_/  /_/ /___/_/_/_/_/\\_,_/_/\\_,_/\\__/\\___/_/}`);
     this.log.info('');
 
     const ref = await GitUtils.getBranch(this.directory);

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -66,7 +66,7 @@ export default class UpCommand extends AbstractServerCommand {
       .withLogger(this._logger)
       .withKill(this._kill)
       .withPrintIndex(this._printIndex);
-    this.log.info(chalk`{yellow     ___   ______  ___  _____            __     __ ${pkgJson.version}}`);
+    this.log.info(chalk`{yellow     ___   ______  ___  _____            __     __  v${pkgJson.version}}`);
     this.log.info(chalk`{yellow    / _ | / __/  |/  / / __(_)_ _  __ __/ /__ _/ /____  ____}`);
     this.log.info(chalk`{yellow   / __ |/ _// /|_/ / _\\ \\/ /  ' \\/ // / / _ \`/ __/ _ \\/ __/}`);
     this.log.info(chalk`{yellow  /_/ |_/___/_/  /_/ /___/_/_/_/_/\\_,_/_/\\_,_/\\__/\\___/_/}`);

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -66,11 +66,12 @@ export default class UpCommand extends AbstractServerCommand {
       .withLogger(this._logger)
       .withKill(this._kill)
       .withPrintIndex(this._printIndex);
-
-    this.log.info(chalk`{yellow     ____              __    ___   v${pkgJson.version}}`);
-    this.log.info(chalk`{yellow    / __/______ ____  / /__ / (_)__  }`);
-    this.log.info(chalk`{yellow   / _// __/ _ \`/ _ \\/  '_// / / _ \\ }`);
-    this.log.info(chalk`{yellow  /_/ /_/  \\_,_/_//_/_/\\_\\/_/_/_//_/ }`);
+    const version = `v${pkgJson.version}`;
+    this.log.info(chalk`{yellow     ___   ______  ___  ____   __         ___      ___}`);
+    this.log.info(chalk`{yellow    / _ | / __/  |/  / / __/__/ /__ ____ / _ \\___ / (_)  _____ ______ __}`);
+    this.log.info(chalk`{yellow   / __ |/ _// /|_/ / / _// _  / _ \`/ -_) // / -_) / / |/ / -_) __/ // /}`);
+    this.log.info(chalk`{yellow  /_/ |_/___/_/  /_/ /___/\\_,_/\\_, /\\__/____/\\__/_/_/|___/\\__/_/  \\_, /}`);
+    this.log.info(chalk`{yellow                              /___/    ${version.padStart(26, ' ')} ___/}`);
     this.log.info('');
 
     const ref = await GitUtils.getBranch(this.directory);
@@ -91,7 +92,7 @@ export default class UpCommand extends AbstractServerCommand {
         this.watchGit();
       }
     } catch (e) {
-      throw Error(`Unable to start Franklin: ${e.message}`);
+      throw Error(`Unable to start AEM: ${e.message}`);
     }
 
     this._project.on('stopped', async () => {

--- a/src/up.js
+++ b/src/up.js
@@ -107,7 +107,7 @@ export default function up() {
         .withBindAddr(argv.addr)
         // only open  browser window when executable is `aem`
         // this prevents the window to be opened during integration tests
-        .withOpen(path.basename(argv.$0) === 'hlx' || path.basename(argv.$0) === 'aem' ? argv.open : false)
+        .withOpen(path.basename(argv.$0) === 'aem' ? argv.open : false)
         .withTLS(argv.tlsKey, argv.tlsCert)
         .withLiveReload(argv.livereload)
         .withUrl(argv.url)

--- a/src/up.js
+++ b/src/up.js
@@ -19,7 +19,7 @@ export default function up() {
       executor = value;
     },
     command: 'up',
-    description: 'Run a Franklin development server',
+    description: 'Run a AEM development server',
     builder: (yargs) => {
       yargs
         .option('open', {
@@ -70,7 +70,7 @@ export default function up() {
         })
         .option('stop-other', {
           alias: 'stopOther',
-          describe: 'Stop other Franklin CLI running on the above port',
+          describe: 'Stop other AEM CLI running on the above port',
           type: 'boolean',
           default: true,
         })
@@ -91,7 +91,7 @@ export default function up() {
           describe: 'Path to local folder to cache the responses (note: this is an alpha feature, it may be removed without notice)',
           type: 'string',
         })
-        .group(['url', 'livereload', 'no-livereload', 'open', 'no-open', 'print-index', 'cache'], 'Franklin Options')
+        .group(['url', 'livereload', 'no-livereload', 'open', 'no-open', 'print-index', 'cache'], 'AEM Options')
 
         .help();
     },
@@ -105,9 +105,9 @@ export default function up() {
       await executor
         .withHttpPort(argv.port)
         .withBindAddr(argv.addr)
-        // only open  browser window when executable is `hlx`
+        // only open  browser window when executable is `aem`
         // this prevents the window to be opened during integration tests
-        .withOpen(path.basename(argv.$0) === 'hlx' ? argv.open : false)
+        .withOpen(path.basename(argv.$0) === 'hlx' || path.basename(argv.$0) === 'aem' ? argv.open : false)
         .withTLS(argv.tlsKey, argv.tlsCert)
         .withLiveReload(argv.livereload)
         .withUrl(argv.url)

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -126,7 +126,7 @@ describe('hlx command line', () => {
     };
     await cli.run(['up', '--log-level', 'silly', '--log-file', 'foo.log']);
     sinon.assert.calledWith(upCmd.handler, {
-      $0: 'hlx',
+      $0: 'aem',
       _: ['up'],
       'log-file': ['foo.log'],
       'log-level': 'silly',

--- a/test/fixtures/all.env
+++ b/test/fixtures/all.env
@@ -3,65 +3,65 @@
 #
 
 # global
-HLX_LOG_LEVEL=debug
-HLX_LOG_FILE=test.log
+AEM_LOG_LEVEL=debug
+AEM_LOG_FILE=test.log
 
 # deploy + package + clean + build + up
-HLX_TARGET=foo
+AEM_TARGET=foo
 
 # build + up
-HLX_FILES=*.htl,*.js
+AEM_FILES=*.htl,*.js
 
 # up
-HLX_HOST=www.project-helix.io
-HLX_OPEN=false
-HLX_LIVERELOAD=false
-HLX_PORT=1234
-HLX_ADDR=*
-HLX_LOCAL_REPO="., ../foo-content, ../bar-content"
-#HLX_SAVE_CONFIG <forbidden use through env>
-HLX_DEV_DEFAULT={"SECRET1": "VALUE1", "SECRET2": 5000}
-HLX_DEV_DEFAULT_FILE=defaults.json
+AEM_HOST=www.project-helix.io
+AEM_OPEN=false
+AEM_LIVERELOAD=false
+AEM_PORT=1234
+AEM_ADDR=*
+AEM_LOCAL_REPO="., ../foo-content, ../bar-content"
+#AEM_SAVE_CONFIG <forbidden use through env>
+AEM_DEV_DEFAULT={"SECRET1": "VALUE1", "SECRET2": 5000}
+AEM_DEV_DEFAULT_FILE=defaults.json
 
-HLX_DEFAULT={"SECRET2": "VALUE2"}
-HLX_DEFAULT_FILE=defaults.env
+AEM_DEFAULT={"SECRET2": "VALUE2"}
+AEM_DEFAULT_FILE=defaults.env
 
 # package
-HLX_FORCE=true
+AEM_FORCE=true
 
 # package + deploy
-HLX_MINIFY=true
+AEM_MINIFY=true
 
 # deploy + publish + perf
-HLX_FASTLY_NAMESPACE=1234
-HLX_FASTLY_AUTH=foobar
+AEM_FASTLY_NAMESPACE=1234
+AEM_FASTLY_AUTH=foobar
 
 # deploy + publish
-HLX_AUTO=true
-HLX_DRY_RUN=true
+AEM_AUTO=true
+AEM_DRY_RUN=true
 
 # deploy
-HLX_CIRCLECI_AUTH=foobar
-HLX_PACKAGE=ignore
-HLX_DIRTY=true
+AEM_CIRCLECI_AUTH=foobar
+AEM_PACKAGE=ignore
+AEM_DIRTY=true
 
-HLX_WSK_AUTH=foobar
-HLX_WSK_NAMESPACE=1234
-HLX_WSK_HOST=myruntime.net
-HLX_SVC_RESOLVE_GIT_REF=resolve.api
+AEM_WSK_AUTH=foobar
+AEM_WSK_NAMESPACE=1234
+AEM_WSK_HOST=myruntime.net
+AEM_SVC_RESOLVE_GIT_REF=resolve.api
 
-#HLX_DEFAULT <forbidden use through env>
-#HLX_ADD = <forbidden use through env>
+#AEM_DEFAULT <forbidden use through env>
+#AEM_ADD = <forbidden use through env>
 
 # publish
-HLX_API_PUBLISH=foobar.api
-HLX_GITHUB_TOKEN=github-token-foobar
-HLX_UPDATE_BOT_CONFIG=true
-HLX_API_CONFIG_PURGE=purge.api
+AEM_API_PUBLISH=foobar.api
+AEM_GITHUB_TOKEN=github-token-foobar
+AEM_UPDATE_BOT_CONFIG=true
+AEM_API_CONFIG_PURGE=purge.api
 
 # perf
-HLX_JUNIT=some-results.xml
-HLX_DEVICE=iPad
-HLX_CONNECTION=good2G
-HLX_LOCATION=California
+AEM_JUNIT=some-results.xml
+AEM_DEVICE=iPad
+AEM_CONNECTION=good2G
+AEM_LOCATION=California
 

--- a/test/git-utils.test.js
+++ b/test/git-utils.test.js
@@ -35,7 +35,7 @@ describe('Testing GitUtils', () => {
     testRoot = await createTestRoot();
     await fse.writeFile(path.resolve(testRoot, 'README.md'), 'Hello\n', 'utf-8');
     await fse.writeFile(path.resolve(testRoot, '.gitignore'), '.env\n', 'utf-8');
-    await fse.writeFile(path.resolve(testRoot, '.env'), 'HLX_BLA=123\n', 'utf-8');
+    await fse.writeFile(path.resolve(testRoot, '.env'), 'AEM_BLA=123\n', 'utf-8');
 
     // throw a Javascript error when any shell.js command encounters an error
     shell.config.fatal = true;

--- a/test/server-livereload.test.js
+++ b/test/server-livereload.test.js
@@ -276,7 +276,7 @@ describe('Helix Server with Livereload', () => {
         protocols: [
           'http://livereload.com/protocols/official-7',
         ],
-        serverName: 'franklin-simulator',
+        serverName: 'aem-simulator',
       });
       assert.deepEqual(wsReloadData, {
         command: 'reload',
@@ -361,7 +361,7 @@ describe('Helix Server with Livereload', () => {
         protocols: [
           'http://livereload.com/protocols/official-7',
         ],
-        serverName: 'franklin-simulator',
+        serverName: 'aem-simulator',
       });
       assert.deepEqual(wsAlertData, {
         command: 'alert',

--- a/test/utils.js
+++ b/test/utils.js
@@ -48,7 +48,7 @@ export function switchBranch(dir, branch) {
 
 export function clearHelixEnv() {
   const deleted = {};
-  Object.keys(process.env).filter((key) => key.startsWith('HLX_')).forEach((key) => {
+  Object.keys(process.env).filter((key) => key.startsWith(('AEM_'))).forEach((key) => {
     deleted[key] = process.env[key];
     delete process.env[key];
   });


### PR DESCRIPTION
BREAKING CHANGE: hlx up and the HLX_ env prefix no longer work. use aem and AEM_ instead.

<img width="645" alt="image" src="https://github.com/adobe/helix-cli/assets/917628/e4bb82ed-fd9f-4df0-babe-857aeb89c867">

fixes #2248 
fixes #2093 