### PR TITLE
fix: show deprecation warning and exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
  */
 
 import CLI from './src/cli.js';
-import { checkNodeVersion, validateDotEnv } from './src/config/config-utils.js';
+import { checkCLIVersion, checkNodeVersion, validateDotEnv } from './src/config/config-utils.js';
 import { config } from 'dotenv';
 
 config();
@@ -21,5 +21,6 @@ config();
 (async () => {
   await checkNodeVersion();
   await validateDotEnv();
+  await checkCLIVersion();
   await new CLI().run(process.argv.slice(2));
 })();

--- a/src/config/config-utils.js
+++ b/src/config/config-utils.js
@@ -47,3 +47,14 @@ You might encounter unexpected errors.
 `);
   }
 }
+/**
+ * Checks if the current cli
+ */
+export function checkCLIVersion() {
+  process.stderr.write(chalk`{red warning:} The @adobe/helix-cli is no longer supported. please install the {cyan aem-cli} instead:
+
+npm install -g @adobe/aem-cli   
+
+`);
+  process.exit(1);
+}

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -46,25 +46,30 @@ describe('hlx command line', () => {
     shell.cd(cwd);
   });
 
-  it('hlx w/o arguments shows help and exits with != 0', () => {
+  it('hlx exits with code 1', () => {
+    const cmd = runCLI();
+    assert.strictEqual(cmd.code, 1);
+  });
+
+  it.skip('hlx w/o arguments shows help and exits with != 0', () => {
     const cmd = runCLI();
     assert.notEqual(cmd.code, 0);
     assert.ok(/.*You need at least one command.*/.test(cmd.stderr));
   });
 
-  it('hlx --version shows version', () => {
+  it.skip('hlx --version shows version', () => {
     const cmd = runCLI('--version');
     assert.equal(cmd.code, 0);
     assert.equal(cmd.stdout.trim(), pkgJson.version);
   });
 
-  it('hlx with unknown command shows help and exists with != 0', () => {
+  it.skip('hlx with unknown command shows help and exists with != 0', () => {
     const cmd = runCLI('foo');
     assert.notEqual(cmd.code, 0);
     assert.ok(/.*Unknown command: foo*/.test(cmd.stderr.toString()));
   });
 
-  it('hlx up with unknown argument shows help and exists with != 0', () => {
+  it.skip('hlx up with unknown argument shows help and exists with != 0', () => {
     const cmd = runCLI('up', '--foo=bar');
     assert.notEqual(cmd.code, 0);
     assert.ok(/.*Unknown argument: foo*/.test(cmd.stderr.toString()));
@@ -79,7 +84,7 @@ describe('hlx command line', () => {
     shell.exec('git add -A');
     shell.exec('git commit -m"initial"');
     const cmd = runCLI('--version');
-    assert.equal(cmd.code, 0);
+    assert.strictEqual(cmd.code, 1);
     assert.ok(cmd.stdout.trim().indexOf('This is typically not good because it might contain secrets') >= 0);
     shell.cd(cwd);
     await fse.remove(testRoot);


### PR DESCRIPTION
shows a deprecation warning and exiits:

<img width="727" alt="image" src="https://github.com/adobe/helix-cli/assets/917628/b310791c-7403-4782-a6ab-684ef2650ea8">
