### PR TITLE
fix: defer loading of head.html to allow inclusion of request cookie

### DIFF
--- a/src/server/HelixProject.js
+++ b/src/server/HelixProject.js
@@ -78,15 +78,13 @@ export class HelixProject extends BaseProject {
         log: this.log,
         proxyUrl: this.proxyUrl,
       });
-      await this._headHtml.init();
 
       // register local head in live-reload
       if (this.liveReload) {
         this.liveReload.registerFiles([this._headHtml.filePath], '/');
         this.liveReload.on('modified', async (modified) => {
           if (modified.indexOf('/') >= 0) {
-            await this._headHtml.loadLocal();
-            await this._headHtml.init();
+            this._headHtml.invalidateLocal();
           }
         });
       }

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -289,7 +289,7 @@ window.LiveReloadOptions = {
 
     const isHTML = ret.status === 200 && contentType.indexOf('text/html') === 0;
     const livereload = isHTML && opts.injectLiveReload;
-    const replaceHead = isHTML && opts.headHtml && opts.headHtml.isModified;
+    const replaceHead = isHTML && opts.headHtml;
     const doIndex = isHTML && opts.indexer && url.indexOf('.plain.html') < 0;
 
     if (isHTML) {
@@ -322,6 +322,7 @@ window.LiveReloadOptions = {
         ctx.log.trace(lines.join('\n'));
       }
       if (replaceHead) {
+        await opts.headHtml.setCookie(req.headers.cookie);
         textBody = await opts.headHtml.replace(textBody);
       }
       if (livereload) {

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -119,7 +119,9 @@ export default class UpCommand extends AbstractServerCommand {
     const resp = await getFetch()(fstabUrl);
     await resp.buffer();
     if (!resp.ok) {
-      if (ref === 'main') {
+      if (resp.status === 401) {
+        this.log.warn(chalk`Unable to verify {yellow ${ref}} branch via {blue ${fstabUrl}} for authenticated sites.`);
+      } else if (ref === 'main') {
         this.log.warn(chalk`Unable to verify {yellow main} branch via {blue ${fstabUrl}} (${resp.status}). Maybe not pushed yet?`);
       } else {
         this.log.warn(chalk`Unable to verify {yellow ${ref}} branch on {blue ${fstabUrl}} (${resp.status}). Fallback to {yellow main} branch.`);

--- a/test/head-html.test.js
+++ b/test/head-html.test.js
@@ -29,7 +29,9 @@ function removePosition(tree) {
 
 async function init(hhs, localHtml, remoteHtml) {
   hhs.localHtml = localHtml;
+  hhs.localStatus = 200;
   hhs.remoteHtml = remoteHtml;
+  hhs.remoteStatus = 200;
   if (remoteHtml) {
     hhs.remoteDom = await HeadHtmlSupport.toDom(hhs.remoteHtml);
     HeadHtmlSupport.hash(hhs.remoteDom);
@@ -149,7 +151,7 @@ describe('Head.html loading tests', () => {
   it('loads remote head.html', async () => {
     const directory = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
 
-    const scope = nock('https://main--blog--adobe.hlx.page')
+    nock('https://main--blog--adobe.hlx.page')
       .get('/head.html')
       .reply(200, '<!-- remote head html -->   <script>a=1;</script>');
 
@@ -180,13 +182,12 @@ describe('Head.html loading tests', () => {
       type: 'root',
     });
     assert.strictEqual(hhs.remoteStatus, 200);
-    scope.done();
   });
 
   it('loads missing remote head.html', async () => {
     const directory = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
 
-    const scope = nock('https://main--blog--adobe.hlx.page')
+    nock('https://main--blog--adobe.hlx.page')
       .get('/head.html')
       .reply(404);
 
@@ -198,10 +199,9 @@ describe('Head.html loading tests', () => {
     await hhs.loadRemote();
     assert.strictEqual(hhs.remoteDom, null);
     assert.strictEqual(hhs.remoteStatus, 404);
-    scope.done();
   });
 
-  it('init loads local and remote head.html', async () => {
+  it('update loads local and remote head.html', async () => {
     const directory = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
 
     nock('https://main--blog--adobe.hlx.page')
@@ -213,20 +213,21 @@ describe('Head.html loading tests', () => {
       proxyUrl: 'https://main--blog--adobe.hlx.page',
       directory,
     });
-    await hhs.init();
+    await hhs.update();
     assert.strictEqual(hhs.remoteHtml, '<!-- remote head html --><a>fooo</a>');
     assert.strictEqual(hhs.remoteStatus, 200);
     assert.strictEqual(hhs.localHtml, '<!-- local head html -->\n<link rel="stylesheet" href="/styles.css"/>');
     assert.strictEqual(hhs.localStatus, 200);
     assert.strictEqual(hhs.isModified, true);
 
-    await hhs.init(); // only once
+    // only once
+    await hhs.update();
   });
 
-  it('init loads local and remote head.html (not modified)', async () => {
+  it('update loads local and remote head.html (not modified)', async () => {
     const directory = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
 
-    const scope = nock('https://main--blog--adobe.hlx.page')
+    nock('https://main--blog--adobe.hlx.page')
       .get('/head.html')
       .reply(200, '<!-- local head html -->\n<link rel="stylesheet" href="/styles.css"/>');
 
@@ -235,34 +236,34 @@ describe('Head.html loading tests', () => {
       proxyUrl: 'https://main--blog--adobe.hlx.page',
       directory,
     });
-    await hhs.init();
+    await hhs.update();
     assert.strictEqual(hhs.remoteHtml, '<!-- local head html -->\n<link rel="stylesheet" href="/styles.css"/>');
     assert.strictEqual(hhs.remoteStatus, 200);
     assert.strictEqual(hhs.localHtml, '<!-- local head html -->\n<link rel="stylesheet" href="/styles.css"/>');
     assert.strictEqual(hhs.localStatus, 200);
     assert.strictEqual(hhs.isModified, false);
 
-    await hhs.init(); // only once
-    scope.done();
+    // only once
+    await hhs.update();
   });
 
-  it('init sets modified to false if local status failed', async () => {
+  it('update sets modified to false if local status failed', async () => {
     const hhs = new HeadHtmlSupport(DEFAULT_OPTS());
     hhs.localHtml = '';
     hhs.remoteHtml = '';
     hhs.localStatus = 404;
     hhs.remoteStatus = 200;
-    await hhs.init();
+    await hhs.update();
     assert.strictEqual(hhs.isModified, false);
   });
 
-  it('init sets modified to false if remote status failed', async () => {
+  it('update sets modified to false if remote status failed', async () => {
     const hhs = new HeadHtmlSupport(DEFAULT_OPTS());
     hhs.localHtml = '';
     hhs.remoteHtml = '';
     hhs.localStatus = 200;
     hhs.remoteStatus = 404;
-    await hhs.init();
+    await hhs.update();
     assert.strictEqual(hhs.isModified, false);
   });
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -104,10 +104,6 @@ describe('Helix Server', () => {
       .withProxyUrl('https://main--foo--bar.hlx.page/')
       .withHttpPort(0);
 
-    nock('https://main--foo--bar.hlx.page')
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
-
     await project.init();
     try {
       await project.start();
@@ -123,10 +119,6 @@ describe('Helix Server', () => {
       .withCwd(cwd)
       .withProxyUrl('https://main--foo--bar.hlx.page/')
       .withHttpPort(0);
-
-    nock('https://main--foo--bar.hlx.page')
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
 
     await project.init();
     try {
@@ -164,9 +156,7 @@ describe('Helix Server', () => {
 
     nock('http://main--foo--bar.hlx.page')
       .get('/notfound.css')
-      .reply(404)
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
+      .reply(404);
 
     try {
       await project.start();
@@ -188,9 +178,7 @@ describe('Helix Server', () => {
     nock('http://main--foo--bar.hlx.page')
       .get('/local.html')
       .optionally(true)
-      .reply(200, 'foo')
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
+      .reply(200, 'foo');
 
     try {
       await project.start();
@@ -219,9 +207,7 @@ describe('Helix Server', () => {
       .get('/missing')
       .reply(404, 'server 404 html', {
         'content-type': 'text/html',
-      })
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
+      });
 
     try {
       await project.start();
@@ -366,10 +352,6 @@ describe('Helix Server', () => {
         // a request like: /subfolder/query-index.json?sheet=foo&limit=20?sheet=foo&limit=20
         assert.strictEqual(uri, '/subfolder/query-index.json?sheet=foo&limit=20');
         return [200, '{ "data": [] }', { 'content-type': 'application/json' }];
-      })
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>', {
-        'content-type': 'text/html',
       });
 
     try {

--- a/test/up-cmd.test.js
+++ b/test/up-cmd.test.js
@@ -63,9 +63,7 @@ describe('Integration test for up command with helix pages', function suite() {
       .get('/index.html')
       .reply(200, '## Welcome')
       .get('/not-found.txt')
-      .reply(404)
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
+      .reply(404);
 
     let port;
     await new Promise((resolve, reject) => {
@@ -116,9 +114,7 @@ describe('Integration test for up command with helix pages', function suite() {
       .get('/index.html')
       .reply(200, '## Welcome')
       .get('/not-found.txt')
-      .reply(404)
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
+      .reply(404);
 
     cmd
       .on('started', async () => {
@@ -158,9 +154,7 @@ describe('Integration test for up command with helix pages', function suite() {
       .get('/index.html')
       .reply(200, '## Welcome')
       .get('/not-found.txt')
-      .reply(404)
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
+      .reply(404);
 
     nock('https://master--dummy-foo--adobe.hlx.page')
       .get('/fstab.yaml')
@@ -204,9 +198,7 @@ describe('Integration test for up command with helix pages', function suite() {
       .get('/index.html')
       .reply(200, '## Welcome')
       .get('/not-found.txt')
-      .reply(404)
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
+      .reply(404);
 
     nock('https://master--dummy-foo--adobe.hlx.page')
       .get('/fstab.yaml')
@@ -214,9 +206,7 @@ describe('Integration test for up command with helix pages', function suite() {
 
     nock('https://new-branch--dummy-foo--adobe.hlx.page')
       .get('/fstab.yaml')
-      .reply(200, 'yep!')
-      .get('/head.html')
-      .reply(200, '## Welcome');
+      .reply(200, 'yep!');
 
     let timer;
     cmd
@@ -261,9 +251,7 @@ describe('Integration test for up command with helix pages', function suite() {
       .get('/index.html')
       .reply(200, '## Welcome')
       .get('/not-found.txt')
-      .reply(404)
-      .get('/head.html')
-      .reply(200, '<link rel="stylesheet" href="/styles.css"/>');
+      .reply(404);
 
     nock('https://master--dummy-foo--adobe.hlx.page')
       .get('/fstab.yaml')


### PR DESCRIPTION
This fix changes the way how the remote head.html is loaded (the remote head.html version is needed to properly calculating how the local head.html needs to be injected into the html page).
instead of fetching the head.html during startup, it is deferred until the proxy server actually needs it. this is after the browser sent eventual request cookie. this allows that the remote head.html can be fetched also for authenticated sites.

fixes #2274
