### PR TITLE
Fix: improve aem up error handling

### DIFF
--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -81,6 +81,9 @@ export default class UpCommand extends AbstractServerCommand {
 
     const ref = await GitUtils.getBranch(this.directory);
     this._gitUrl = await GitUtils.getOriginURL(this.directory, { ref });
+    if (!this._gitUrl) {
+      throw Error('No git remote found. Make sure you have a remote "origin" configured.');
+    }
     if (!this._url) {
       await this.verifyUrl(this._gitUrl, ref);
     }


### PR DESCRIPTION
## Related Issues
https://github.com/adobe/helix-cli/issues/2369

## Description
Provide a better error in case the `gitUrl` is not found due to not having configured a remote 'origin', rather than a JS error without any hints on what went wrong.

## Before
![image](https://github.com/adobe/helix-cli/assets/39759830/0b32d686-6f55-4876-bc7f-5ce7fe051db5)

## After
![image](https://github.com/adobe/helix-cli/assets/39759830/f1b52726-5609-4544-aebb-dca3c4ee0eaf)
