### PR TITLE
fix: update command name in message from 'hlx' to 'aem'

### DIFF
--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -59,7 +59,7 @@ export default class UpCommand extends AbstractServerCommand {
       }
     } catch (e) {
       if (e.code === 'ENOENT') {
-        throw Error('hlx up needs local git repository.');
+        throw Error('aem up needs local git repository.');
       }
       throw e;
     }


### PR DESCRIPTION
## Related Issues
#2248

## Description
Fixing an error message I encountered, that mentioned the deprecated `hlx` command name