### PR TITLE
#2426 Allow import branch specification

### DIFF
--- a/src/git-utils.js
+++ b/src/git-utils.js
@@ -23,6 +23,8 @@ import git from 'isomorphic-git';
 const cache = {};
 
 export default class GitUtils {
+  static DEFAULT_BRANCH = 'main';
+
   /**
    * Determines whether the working tree directory contains uncommitted or unstaged changes.
    *
@@ -141,7 +143,7 @@ export default class GitUtils {
    * @param {string} fallback fallback value if no branch or tag is found
    * @returns {Promise<string>} current branch or tag
    */
-  static async getBranch(dir, fallback = 'main') {
+  static async getBranch(dir, fallback = this.DEFAULT_BRANCH) {
     // current commit sha
     const rev = await git.resolveRef({ fs, dir, ref: 'HEAD' });
     // reverse-lookup tag from commit sha

--- a/src/import.js
+++ b/src/import.js
@@ -29,7 +29,7 @@ export default function up() {
         })
         .option('ui-repo', {
           alias: 'uiRepo',
-          describe: 'Git repository for the AEM Importer UI',
+          describe: 'Git repository for the AEM Importer UI. A fragment may be used to indicated a branch other than main.',
           type: 'string',
           default: 'https://github.com/adobe/helix-importer-ui',
         })

--- a/test/import-cmd.test.js
+++ b/test/import-cmd.test.js
@@ -15,6 +15,7 @@ import assert from 'assert';
 import path from 'path';
 import fse from 'fs-extra';
 import { h1NoCache as fetchContext } from '@adobe/fetch';
+import GitUtils from '../src/git-utils.js';
 import {
   Nock,
   assertHttp,
@@ -595,7 +596,7 @@ describe('Import command - importer ui', function suite() {
       .catch(done);
   });
 
-  it('import command installs a importer ui branch', (done) => {
+  it('import command installs a importer ui test branch', (done) => {
     // This assumes the branch 'origin/test' will exist and be available.
     let error = null;
     const cmd = new ImportCommand()
@@ -628,7 +629,7 @@ describe('Import command - importer ui', function suite() {
       .catch(done);
   });
 
-  it('import command fails to install a importer ui branch', (done) => {
+  it('import command fails to install a bad branch', (done) => {
     // This assumes the branch 'origin/bad' does not exist.
     let error = null;
     const cmd = new ImportCommand()
@@ -657,20 +658,79 @@ describe('Import command - importer ui', function suite() {
       .run()
       .catch(() => {
         done();
-        assert.success('Importer UI branch does not exist - exception expected.');
       });
   });
 
-  it('import command fails to install an invalid ui-repo', (done) => {
+  it('import command fails to install an invalid ui-repo', () => {
     try {
       new ImportCommand()
         .withDirectory(testDir)
         .withOpen(false)
         .withUIRepo('not a url#hash')
         .withHttpPort(0);
+      assert.fail('Importer UI repo URL was invalid - exception expected.');
     } catch (e) {
-      done();
-      assert.success('Importer UI repo URL was invalid - exception expected.');
+      assert.equal(e.message, 'Invalid URL');
     }
+  });
+
+  /**
+   * Testing starting the importer on the default (main) branch, and switching it to a test
+   * branch.
+   */
+  it('import command handles an empty branch', () => {
+    try {
+      const cmd = new ImportCommand()
+        .withDirectory(testDir)
+        .withOpen(false)
+        .withUIRepo('https://github.com/adobe/helix-importer-ui#')
+        .withHttpPort(0);
+      // eslint-disable-next-line no-underscore-dangle
+      assert.equal(cmd._uiRepo, 'https://github.com/adobe/helix-importer-ui');
+      // eslint-disable-next-line no-underscore-dangle
+      assert.equal(cmd._uiBranch, GitUtils.DEFAULT_BRANCH);
+    } catch (e) {
+      assert.fail('Importer UI repo URL was valid - exception not expected.');
+    }
+  });
+
+  it('import command switches branch', (done) => {
+    const cmd = new ImportCommand()
+      .withDirectory(testDir)
+      .withOpen(false)
+      .withUIRepo('https://github.com/adobe/helix-importer-ui#')
+      .withHttpPort(0);
+    cmd
+      .on('started', async () => {
+        const mainBranch = await getBranch(`${testDir}/tools/importer/helix-importer-ui`);
+        assert.equal(mainBranch, 'main');
+
+        await cmd.stop();
+      })
+      .on('stopped', async () => {
+        // Main branch server has stopped.  Now switch it to 'test'.
+        const cmd2 = new ImportCommand()
+          .withDirectory(testDir)
+          .withOpen(false)
+          .withUIRepo('https://github.com/adobe/helix-importer-ui#test')
+          .withHttpPort(0);
+        cmd2
+          .on('started', async () => {
+            const testBranch = await getBranch(`${testDir}/tools/importer/helix-importer-ui`);
+            assert.equal(testBranch, 'test');
+            await cmd2.stop();
+          })
+          .on('stopped', () => {
+            done();
+          })
+          .run()
+          .catch((e) => {
+            done(e);
+          });
+      })
+      .run()
+      .catch((e) => {
+        done(e);
+      });
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -43,7 +43,19 @@ export function switchBranch(dir, branch) {
   shell.cd(dir);
   shell.exec(`git checkout -b ${branch}`);
   shell.cd(pwd);
+  // eslint-disable-next-line no-console
   console.log(`switched to branch ${branch} in ${dir}`);
+}
+
+export function getBranch(dir) {
+  const pwd = shell.pwd();
+  shell.cd(dir);
+  const { stdout } = shell.exec('git rev-parse --abbrev-ref HEAD');
+  shell.cd(pwd);
+  // eslint-disable-next-line no-console
+  console.log(`The current branch is ${stdout.trim()} in ${dir}`);
+
+  return stdout.trim();
 }
 
 export function clearHelixEnv() {


### PR DESCRIPTION
Extend the `--ui-repo` parameter to allow a branch specifier, which will make socializing new feature branches easier:
`aem import -ui-repo=https://github.com/adobe/helix-importer-ui#<by-branch>`

## Related Issues
#2426 

@kptdobe I realize you didn't really support this idea, but I went ahead to see the effort involved.

cc @arumsey @catalan-adobe @karlpauls 

Missing from this is an indicator on the UI of the branch, other than 'main', that is being used.  I tried a few ways but thought I would submit this PR without it.  Output from `aem import` is explicit about the branch.


