### PR TITLE
fix: Force Selecting Account when logging in via the CLI

### DIFF
--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -106,7 +106,7 @@ export default class UpCommand extends AbstractServerCommand {
         .withOrg(org)
         .withSiteLoginUrl(
           // TODO switch to production URL
-          `https://admin.hlx.page/login/${org}/${site}/main?client_id=aem-cli&redirect_uri=${encodeURIComponent(`http://localhost:${this._httpPort}/.aem/cli/login/ack`)}`,
+          `https://admin.hlx.page/login/${org}/${site}/main?client_id=aem-cli&redirect_uri=${encodeURIComponent(`http://localhost:${this._httpPort}/.aem/cli/login/ack`)}&selectAccount=true`,
         );
     }
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -450,7 +450,7 @@ describe('Helix Server', () => {
       .withCwd(cwd)
       .withHttpPort(3000)
       .withProxyUrl('http://main--foo--bar.aem.page')
-      .withSiteLoginUrl('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack');
+      .withSiteLoginUrl('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack&selectAccount=true');
 
     await project.init();
     project.log.level = 'silly';
@@ -463,7 +463,7 @@ describe('Helix Server', () => {
       });
       assert.strictEqual(resp.status, 302);
       assert.ok(
-        resp.headers.get('location').startsWith('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack&state='),
+        resp.headers.get('location').startsWith('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack&selectAccount=true&state='),
       );
     } finally {
       await project.stop();
@@ -476,7 +476,7 @@ describe('Helix Server', () => {
       .withCwd(cwd)
       .withHttpPort(3000)
       .withProxyUrl('http://main--foo--bar.aem.page')
-      .withSiteLoginUrl('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack');
+      .withSiteLoginUrl('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack&selectAccount=true');
 
     await project.init();
     project.log.level = 'silly';
@@ -509,7 +509,7 @@ describe('Helix Server', () => {
       .withCwd(cwd)
       .withHttpPort(3000)
       .withProxyUrl('http://main--foo--bar.aem.page')
-      .withSiteLoginUrl('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack');
+      .withSiteLoginUrl('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack&selectAccount=true');
 
     await project.init();
     project.log.level = 'silly';
@@ -591,7 +591,7 @@ describe('Helix Server', () => {
       .withCwd(cwd)
       .withHttpPort(3000)
       .withProxyUrl('http://main--foo--bar.aem.page')
-      .withSiteLoginUrl('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack');
+      .withSiteLoginUrl('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack&selectAccount=true');
 
     await project.init();
     project.log.level = 'silly';
@@ -637,7 +637,7 @@ describe('Helix Server', () => {
       .withCwd(cwd)
       .withHttpPort(3000)
       .withProxyUrl('http://main--foo--bar.aem.page')
-      .withSiteLoginUrl('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack');
+      .withSiteLoginUrl('https://admin.hlx.page/login/bar/foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F.aem%2Fcli%2Flogin%2Fack&selectAccount=true');
 
     await project.init();
     project.log.level = 'silly';

--- a/test/up-cmd.test.js
+++ b/test/up-cmd.test.js
@@ -196,7 +196,7 @@ describe('Integration test for up command with helix pages', function suite() {
               resp.headers
                 .get('location')
                 .startsWith(
-                  'https://admin.hlx.page/login/adobe/dummy-foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A0%2F.aem%2Fcli%2Flogin%2Fack&state=',
+                  'https://admin.hlx.page/login/adobe/dummy-foo/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A0%2F.aem%2Fcli%2Flogin%2Fack&selectAccount=true&state=',
                 ),
             );
           } catch (e) {
@@ -256,7 +256,7 @@ describe('Integration test for up command with helix pages', function suite() {
               resp.headers
                 .get('location')
                 .startsWith(
-                  'https://admin.hlx.page/login/adobe/dummy/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A0%2F.aem%2Fcli%2Flogin%2Fack&state=',
+                  'https://admin.hlx.page/login/adobe/dummy/main?client_id=aem-cli&redirect_uri=http%3A%2F%2Flocalhost%3A0%2F.aem%2Fcli%2Flogin%2Fack&selectAccount=true&state=',
                 ),
             );
           } catch (e) {


### PR DESCRIPTION
Some IDP configurations do not support the option of prompting to skip login and for these the CLI login fails, as state information is not carried between retries.
In order to fix this, we use `selectAccount=true` from the beginning for Helix CLI logins.