### PR TITLE
Remove accept-encoding in proxy call to use nodejs defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "c8 mocha",
     "test-ci-win": "npx mocha --reporter xunit test --reporter-options output=junit/test.xml -t 5000",
     "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
     "semantic-release": "semantic-release",
     "semantic-release-dry": "semantic-release --dry-run --branches $CI_BRANCH",
     "prepare": "husky"

--- a/src/server/HelixImportServer.js
+++ b/src/server/HelixImportServer.js
@@ -105,6 +105,7 @@ export class HelixImportServer extends BaseServer {
     delete headers.connection;
     delete headers.host;
     delete headers.referer;
+    delete headers['accept-encoding'];
     await this._updateHeaders(headers);
 
     const ret = await getFetch(ctx.config.allowInsecure)(url, {


### PR DESCRIPTION
One of our customer sites was optionally using zstd, which is not supported and was causing a blob to be returned as the body instead of the actual html.