### PR TITLE
MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ $ aem up
 The `--open` argument takes a path, eg `--open=/products/`, will cause the browser to be openend
 at the specific location. Disable with `--no-open'.`
 
+### Using AEM as an MCP Server
+
+AEM can be used as an MCP Server in GitHub Copilot, Cursor, Claude Code and other tools that support Model Protocol (MCP).
+
+To use AEM as an MCP server, add the following command to your IDE: `npx @adobe/aem-cli mcp`. No additional configuration is required.
+
+You can then ask your AI assistant to start or stop an AEM server in your working directory or retrieve the logs of the current server.
+
 ### setting up a self-signed cert for using https
 
 1. create the certificate

--- a/src/cli.js
+++ b/src/cli.js
@@ -105,7 +105,7 @@ export default class CLI {
   async initCommands() {
     if (!this._commands) {
       this._commands = {};
-      for (const cmd of ['up', 'hack', 'import']) {
+      for (const cmd of ['up', 'hack', 'import', 'mcp']) {
         if (!this._commands[cmd]) {
           // eslint-disable-next-line no-await-in-loop
           this._commands[cmd] = (await import(`./${cmd}.js`)).default();

--- a/src/mcp-logger.js
+++ b/src/mcp-logger.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// In-memory store for log messages
+const LOG_BUFFER = [];
+const MAX_LOG_ENTRIES = 1000; // Limit the number of log entries in memory
+
+/**
+ * Add a log entry to the in-memory buffer
+ * @param {string} level Log level
+ * @param {string} message Log message
+ * @param {Object} [context] Additional context
+ */
+function addLogEntry(level, message, context = {}) {
+  // Create a structured log entry
+  const logEntry = {
+    timestamp: new Date().toISOString(),
+    level: level.toLowerCase(),
+    message,
+    context: { ...context },
+  };
+
+  // Add to buffer with truncation if needed
+  LOG_BUFFER.push(logEntry);
+  if (LOG_BUFFER.length > MAX_LOG_ENTRIES) {
+    LOG_BUFFER.shift(); // Remove oldest log entry
+  }
+}
+
+/**
+ * Get log entries from the in-memory buffer
+ * @param {number} lines Number of lines to return
+ * @param {string} filter Optional filter string
+ * @param {number} seconds Optional time range in seconds
+ * @param {Array<string>} levels Optional array of log levels to include
+ * @returns {Array} Array of log entry objects
+ */
+export function getLogs(lines = MAX_LOG_ENTRIES, filter = '', seconds = null, levels = null) {
+  // Start with a copy of all logs
+  let logs = [...LOG_BUFFER];
+
+  // Filter by time range if seconds is specified
+  if (seconds !== null && !Number.isNaN(seconds)) {
+    const cutoffTime = new Date(Date.now() - (seconds * 1000)).toISOString();
+    logs = logs.filter((entry) => entry.timestamp >= cutoffTime);
+  }
+
+  // Filter by log levels if specified
+  if (levels !== null && Array.isArray(levels) && levels.length > 0) {
+    logs = logs.filter((entry) => levels.includes(entry.level));
+  }
+
+  // Apply text filter if provided
+  if (filter) {
+    const filterLower = filter.toLowerCase();
+    logs = logs.filter((entry) => {
+      const levelMatch = entry.level.includes(filterLower);
+      const messageMatch = entry.message.toLowerCase().includes(filterLower);
+      const contextMatch = JSON.stringify(entry.context).toLowerCase().includes(filterLower);
+      return levelMatch || messageMatch || contextMatch;
+    });
+  }
+
+  // If seconds was specified, return all logs in that time range
+  // Otherwise, get the last N entries
+  return seconds !== null ? logs : logs.slice(-lines);
+}
+
+/**
+ * Create a logger that implements the Helix Logging SimpleInterface
+ * and stores logs in memory
+ * @param {string} [category='mcp'] Logger category
+ * @returns {Object} Logger instance
+ */
+export function createInMemoryLogger(category = 'mcp') {
+  // Create a base logger object
+  const logger = {
+    category,
+  };
+
+  // Add log methods for each level
+  ['debug', 'info', 'warn', 'error'].forEach((level) => {
+    logger[level] = (message, context = {}) => {
+      // Add category to context if not already present
+      const contextWithCategory = { ...context };
+      if (!contextWithCategory.category) {
+        contextWithCategory.category = category;
+      }
+
+      // Add log entry to buffer
+      addLogEntry(level, message, contextWithCategory);
+    };
+  });
+
+  return logger;
+}
+
+/**
+ * Create a logger factory function that conforms to SimpleInterface
+ * @returns {Function} Logger factory function
+ */
+export function createLoggerFactory() {
+  return (category) => createInMemoryLogger(category);
+}
+
+export default {
+  createLogger: createInMemoryLogger,
+  getLogs,
+};

--- a/src/mcp-logger.js
+++ b/src/mcp-logger.js
@@ -76,6 +76,14 @@ export function getLogs(lines = MAX_LOG_ENTRIES, filter = '', seconds = null, le
 }
 
 /**
+ * Reset the log buffer (primarily for testing)
+ * @returns {void}
+ */
+export function resetLogs() {
+  LOG_BUFFER.length = 0;
+}
+
+/**
  * Create a logger that implements the Helix Logging SimpleInterface
  * and stores logs in memory
  * @param {string} [category='mcp'] Logger category
@@ -115,4 +123,5 @@ export function createLoggerFactory() {
 export default {
   createLogger: createInMemoryLogger,
   getLogs,
+  resetLogs,
 };

--- a/src/mcp.cmd.js
+++ b/src/mcp.cmd.js
@@ -114,6 +114,7 @@ export default class MCPCommand extends AbstractCommand {
       result,
     };
     this.log.debug(`Sending response: ${JSON.stringify(response)}`);
+    // eslint-disable-next-line no-console
     console.log(JSON.stringify(response));
   }
 
@@ -127,6 +128,7 @@ export default class MCPCommand extends AbstractCommand {
       },
     };
     this.log.debug(`Sending error response: ${JSON.stringify(response)}`);
+    // eslint-disable-next-line no-console
     console.log(JSON.stringify(response));
   }
 }

--- a/src/mcp.cmd.js
+++ b/src/mcp.cmd.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import readline from 'readline';
+import { AbstractCommand } from './abstract.cmd.js';
+
+export default class MCPCommand extends AbstractCommand {
+  constructor(logger) {
+    super(logger);
+    this._tools = [];
+  }
+
+  withTools(tools) {
+    this._tools = tools || [];
+    return this;
+  }
+
+  async run() {
+    this.log.info('Starting MCP server...');
+
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    });
+
+    rl.on('line', (line) => {
+      try {
+        const request = JSON.parse(line);
+        this.handleRequest(request);
+      } catch (error) {
+        this.log.error(`Error processing request: ${error.message}`);
+        this.sendErrorResponse(-32700, 'Parse error', null);
+      }
+    });
+
+    this.log.info('MCP server ready. Reading from stdin...');
+  }
+
+  handleRequest(request) {
+    const { method, id } = request;
+
+    if (method === 'initialize') {
+      this.sendResponse(id, {
+        protocolVersion: '2024-11-05',
+        capabilities: {
+          experimental: {},
+          prompts: { listChanged: false },
+          resources: { subscribe: false, listChanged: false },
+          tools: { listChanged: false },
+        },
+        serverInfo: {
+          name: 'helix-cli-mcp',
+          version: '0.0.1',
+        },
+      });
+    } else if (method === 'notifications/initialized') {
+      // Do nothing
+    } else if (method === 'tools/list') {
+      this.sendResponse(id, {
+        tools: this._tools,
+      });
+    } else if (method === 'resources/list') {
+      this.sendResponse(id, {
+        resources: [],
+      });
+    } else if (method === 'prompts/list') {
+      this.sendResponse(id, {
+        prompts: [],
+      });
+    } else if (method === 'tools/call') {
+      this.handleToolCall(request, id);
+    } else if (method === 'ping') {
+      this.sendResponse(id, {});
+    } else {
+      this.sendErrorResponse(id, -32601, 'Method not found');
+    }
+  }
+
+  async handleToolCall(request, id) {
+    const { name, arguments: args } = request.params;
+    const tool = this._tools.find((t) => t.name === name);
+
+    if (!tool) {
+      this.sendErrorResponse(id, -32601, `Tool '${name}' not found`);
+      return;
+    }
+
+    try {
+      if (typeof tool.execute === 'function') {
+        const result = await Promise.resolve(tool.execute(args));
+        this.sendResponse(id, result);
+      } else {
+        this.sendErrorResponse(id, -32603, `Tool '${name}' does not have an execute function`);
+      }
+    } catch (error) {
+      this.log.error(`Error executing tool ${name}: ${error.message}`);
+      this.sendErrorResponse(id, -32603, `Error executing tool: ${error.message}`);
+    }
+  }
+
+  sendResponse(id, result) {
+    const response = {
+      jsonrpc: '2.0',
+      id,
+      result,
+    };
+    this.log.debug(`Sending response: ${JSON.stringify(response)}`);
+    console.log(JSON.stringify(response));
+  }
+
+  sendErrorResponse(id, code, message) {
+    const response = {
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code,
+        message,
+      },
+    };
+    this.log.debug(`Sending error response: ${JSON.stringify(response)}`);
+    console.log(JSON.stringify(response));
+  }
+}

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { getOrCreateLogger } from './log-common.js';
+import upTool from './tools/up.js';
+import stopTool from './tools/stop.js';
+import logsTool from './tools/logs.js';
+
+export default function mcp() {
+  let executor;
+  return {
+    command: 'mcp',
+    aliases: [],
+    builder: (yargs) => {
+      yargs
+        .help();
+    },
+    handler: async (argv) => {
+      if (!executor) {
+        const MCPCommand = (await import('./mcp.cmd.js')).default;
+        executor = new MCPCommand(getOrCreateLogger(argv));
+        executor.withTools([upTool, stopTool, logsTool]);
+      }
+
+      await executor
+        .run();
+    },
+  };
+}

--- a/src/tools/logs.js
+++ b/src/tools/logs.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { getLogs } from '../mcp-logger.js';
+
+/**
+ * Tool to retrieve log entries from the in-memory logger
+ */
+const logsTool = {
+  name: 'logs',
+  description: 'Retrieve the last log entries from the MCP server.\n\nArgs:\n lines, filter',
+  inputSchema: {
+    properties: {
+      lines: {
+        title: 'Lines',
+        type: 'integer',
+        default: 20,
+        description: 'Number of log lines to retrieve',
+      },
+      seconds: {
+        title: 'Seconds',
+        type: 'integer',
+        description: 'Number of seconds to retrieve logs for',
+      },
+      filter: {
+        title: 'Filter',
+        type: 'string',
+        description: 'Optional text to filter log lines (case-insensitive)',
+      },
+      levels: {
+        title: 'Levels',
+        type: 'array',
+        default: ['info', 'warn', 'error'],
+        items: {
+          enum: ['silly', 'debug', 'info', 'warn', 'error'],
+        },
+        description: 'Optional array of log levels to filter',
+      },
+    },
+    type: 'object',
+  },
+  execute: async (args) => {
+    try {
+      const lines = args.lines || 20;
+      const filter = args.filter || '';
+      const seconds = args.seconds || null;
+      const levels = args.levels || null;
+
+      // Get structured logs from in-memory buffer
+      // If seconds is specified, it takes precedence over lines
+      const logEntries = getLogs(lines, filter, seconds, levels);
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify(logEntries, null, 2) || 'No log entries found.',
+        }],
+        isError: false,
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Error retrieving logs: ${error.message}`,
+        }],
+        isError: true,
+      };
+    }
+  },
+};
+
+export default logsTool;

--- a/src/tools/stop.js
+++ b/src/tools/stop.js
@@ -85,7 +85,7 @@ const stopTool = {
       }
 
       // Stop a specific server
-      const port = args.port || '3000';
+      const port = args.port ? args.port.toString() : '3000';
       const server = runningServers.get(port);
 
       if (!server) {

--- a/src/tools/stop.js
+++ b/src/tools/stop.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { getOrCreateLogger } from '../log-common.js';
+
+// Store running server instances so they can be stopped
+const runningServers = new Map();
+
+// Register a server for later stopping
+export function registerServer(port, serverInstance) {
+  runningServers.set(port.toString(), serverInstance);
+}
+
+/**
+ * Tool to stop running AEM development servers
+ */
+const stopTool = {
+  name: 'stop',
+  description: 'Stop a running AEM development server.\n\nArgs:\n port',
+  inputSchema: {
+    properties: {
+      port: {
+        title: 'Port',
+        type: 'integer',
+        default: 3000,
+        description: 'Port of the development server to stop',
+      },
+      all: {
+        title: 'All',
+        type: 'boolean',
+        default: true,
+        description: 'Stop all running servers',
+      },
+    },
+    type: 'object',
+  },
+  execute: async (args) => {
+    try {
+      const logger = getOrCreateLogger();
+
+      if (args.all) {
+        // Stop all servers
+        if (runningServers.size === 0) {
+          return {
+            content: [{
+              type: 'text',
+              text: 'No running AEM servers found.',
+            }],
+            isError: false,
+          };
+        }
+
+        const ports = [...runningServers.keys()];
+        let stoppedCount = 0;
+
+        // Use Promise.all to avoid await in a loop
+        await Promise.all(ports.map(async (port) => {
+          const server = runningServers.get(port);
+          if (server) {
+            try {
+              await server.doStop();
+              runningServers.delete(port);
+              stoppedCount += 1; // Use += 1 instead of ++
+            } catch (err) {
+              logger.error(`Error stopping server on port ${port}: ${err.message}`);
+            }
+          }
+        }));
+
+        return {
+          content: [{
+            type: 'text',
+            text: `Stopped ${stoppedCount} AEM server(s).`,
+          }],
+          isError: false,
+        };
+      }
+
+      // Stop a specific server
+      const port = args.port || '3000';
+      const server = runningServers.get(port);
+
+      if (!server) {
+        return {
+          content: [{
+            type: 'text',
+            text: `No AEM server running on port ${port}.`,
+          }],
+          isError: false,
+        };
+      }
+
+      await server.doStop();
+      runningServers.delete(port);
+
+      return {
+        content: [{
+          type: 'text',
+          text: `AEM development server on port ${port} stopped.`,
+        }],
+        isError: false,
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Error stopping AEM server: ${error.message}`,
+        }],
+        isError: true,
+      };
+    }
+  },
+};
+
+export default stopTool;

--- a/src/tools/up.js
+++ b/src/tools/up.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import UpCommandImpl from '../up.cmd.js';
+import { createInMemoryLogger } from '../mcp-logger.js';
+import { registerServer } from './stop.js';
+
+/**
+ * Adapter for the up command as an MCP tool
+ */
+const upTool = {
+  name: 'up',
+  description: 'Run an AEM development server.\n\nArgs:\n port, open, livereload, etc.',
+  inputSchema: {
+    properties: {
+      port: {
+        title: 'Port',
+        type: 'integer',
+        default: 3000,
+        description: 'Development server port',
+      },
+      addr: {
+        title: 'Address',
+        type: 'string',
+        description: 'Development server bind address',
+      },
+      open: {
+        title: 'Open',
+        type: 'string',
+        description: 'Path to open in browser',
+      },
+      livereload: {
+        title: 'LiveReload',
+        type: 'boolean',
+        default: true,
+        description: 'Enable automatic reloading of modified sources in browser',
+      },
+      url: {
+        title: 'URL',
+        type: 'string',
+        description: 'The origin url to fetch content from',
+      },
+      tlsCert: {
+        title: 'TLS Certificate',
+        type: 'string',
+        description: 'Path to .pem file (for enabling TLS)',
+      },
+      tlsKey: {
+        title: 'TLS Key',
+        type: 'string',
+        description: 'Path to .key file (for enabling TLS)',
+      },
+    },
+    type: 'object',
+  },
+  execute: async (args) => {
+    try {
+      const logger = createInMemoryLogger('up');
+      const executor = new UpCommandImpl(logger);
+
+      // Convert string ports to numbers if necessary
+      const port = args.port ? parseInt(args.port, 10) : 3000;
+
+      // Set up the command with all possible options from args
+      executor
+        .withHttpPort(port)
+        .withBindAddr(args.addr || '127.0.0.1')
+        .withOpen(args.open || false)
+        .withTLS(args.tlsKey, args.tlsCert)
+        .withLiveReload(args.livereload !== undefined ? args.livereload : true);
+
+      if (args.url) {
+        executor.withUrl(args.url);
+      }
+
+      if (args.siteToken) {
+        executor.withSiteToken(args.siteToken);
+      }
+
+      if (args.allowInsecure !== undefined) {
+        executor.withAllowInsecure(args.allowInsecure);
+      }
+
+      if (args.printIndex !== undefined) {
+        executor.withPrintIndex(args.printIndex);
+      }
+
+      // Register the server instance for later stopping
+      registerServer(port, executor);
+
+      // Start the server without blocking
+      executor.run().catch((error) => {
+        logger.error(`Error starting AEM server: ${error.message}`);
+      });
+
+      return {
+        content: [{
+          type: 'text',
+          text: `AEM development server started on port ${port}. Open http://localhost:${port} to view the site.`,
+        }],
+        isError: false,
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Error starting AEM server: ${error.message}`,
+        }],
+        isError: true,
+      };
+    }
+  },
+};
+
+export default upTool;

--- a/test/mcp-cli.test.js
+++ b/test/mcp-cli.test.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+import assert from 'assert';
+import sinon from 'sinon';
+import { createTestLogger } from '@adobe/helix-log';
+import esmock from 'esmock';
+import mcp from '../src/mcp.js';
+import MCPCommand from '../src/mcp.cmd.js';
+
+describe('Test hlx MCP CLI', () => {
+  it('hlx mcp command structure', async () => {
+    // Test command structure
+    const mcpCmd = mcp();
+    assert.equal(mcpCmd.command, 'mcp');
+    assert.equal(Array.isArray(mcpCmd.aliases), true);
+    assert.equal(typeof mcpCmd.builder, 'function');
+    assert.equal(typeof mcpCmd.handler, 'function');
+  });
+
+  it('mcp command builder configures yargs', async () => {
+    const yargs = {
+      help: sinon.spy(),
+    };
+
+    const mcpCmd = mcp();
+    mcpCmd.builder(yargs);
+
+    sinon.assert.calledOnce(yargs.help);
+  });
+
+  it('mcp command initialization', async () => {
+    // Initialize with logger and verify it's passed to the command
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    assert.strictEqual(cmd.log, logger);
+    // eslint-disable-next-line no-underscore-dangle
+    assert.equal(Array.isArray(cmd._tools), true);
+  });
+
+  it('mcp command allows tools registration', async () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    const mockTools = [{ name: 'mock-tool' }];
+    const result = cmd.withTools(mockTools);
+
+    // Should return itself for chaining
+    assert.strictEqual(result, cmd);
+    // Tools should be stored
+    // eslint-disable-next-line no-underscore-dangle
+    assert.deepStrictEqual(cmd._tools, mockTools);
+  });
+
+  it('handler initializes and runs executor', async () => {
+    // Create mock executor and run method
+    const runSpy = sinon.spy();
+    const mockExecutor = {
+      run: runSpy,
+      withTools: () => mockExecutor, // Return self for chaining
+    };
+
+    // Spy on the withTools method
+    const withToolsSpy = sinon.spy(mockExecutor, 'withTools');
+
+    // Create a stub MCPCommand constructor
+    const MockCommandStub = sinon.stub().returns(mockExecutor);
+
+    // Create a mocked version of the mcp module
+    const mockedMcp = await esmock.p('../src/mcp.js', import.meta.url, {
+      // eslint-disable-next-line no-extra-parens
+      '../src/mcp.cmd.js': { default: MockCommandStub },
+    });
+
+    const mcpHandler = mockedMcp().handler;
+
+    // Execute the handler
+    await mcpHandler({ logLevel: 'info' });
+
+    // Verify executor was created and run was called
+    sinon.assert.calledOnce(MockCommandStub);
+    sinon.assert.calledOnce(withToolsSpy);
+    sinon.assert.calledOnce(runSpy);
+
+    // Reset the spies
+    MockCommandStub.resetHistory();
+    withToolsSpy.resetHistory();
+    runSpy.resetHistory();
+
+    // Execute again
+    await mcpHandler({ logLevel: 'debug' });
+
+    // Verify executor was not created again
+    sinon.assert.notCalled(MockCommandStub);
+    sinon.assert.notCalled(withToolsSpy);
+
+    // But run was called again
+    sinon.assert.calledOnce(runSpy);
+  });
+});

--- a/test/mcp-cmd.test.js
+++ b/test/mcp-cmd.test.js
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+import assert from 'assert';
+import sinon from 'sinon';
+import { EventEmitter } from 'events';
+import { createTestLogger } from '@adobe/helix-log';
+import esmock from 'esmock';
+import MCPCommand from '../src/mcp.cmd.js';
+
+describe('MCP Command', () => {
+  let consoleLogStub;
+
+  beforeEach(() => {
+    // Stub console.log to capture JSON-RPC responses
+    consoleLogStub = sinon.stub(console, 'log');
+  });
+
+  afterEach(() => {
+    consoleLogStub.restore();
+    sinon.restore();
+  });
+
+  it('initializes with provided logger', () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    assert.strictEqual(cmd.log, logger);
+    // eslint-disable-next-line no-underscore-dangle
+    assert.deepStrictEqual(cmd._tools, []);
+  });
+
+  it('registers tools via withTools method', () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+    const tools = [{ name: 'test-tool' }];
+
+    const result = cmd.withTools(tools);
+
+    // Should return self for chaining
+    assert.strictEqual(result, cmd);
+    // eslint-disable-next-line no-underscore-dangle
+    assert.deepStrictEqual(cmd._tools, tools);
+  });
+
+  it('handles falsy tools parameter in withTools method', () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    // Call withTools with null/undefined
+    const result = cmd.withTools(null);
+
+    // Should return self for chaining
+    assert.strictEqual(result, cmd);
+    // eslint-disable-next-line no-underscore-dangle
+    assert.deepStrictEqual(cmd._tools, []);
+  });
+
+  it('handles initialize request', async () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    // Call the handler directly
+    cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      id: 1,
+    });
+
+    // Verify response
+    sinon.assert.calledOnce(consoleLogStub);
+    const response = JSON.parse(consoleLogStub.firstCall.args[0]);
+    assert.equal(response.id, 1);
+    assert.equal(response.jsonrpc, '2.0');
+    assert.equal(response.result.protocolVersion, '2024-11-05');
+    assert.equal(response.result.serverInfo.name, 'helix-cli-mcp');
+  });
+
+  it('handles notifications/initialized request (no response)', async () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    // Create spy for sendResponse
+    const sendResponseSpy = sinon.spy(cmd, 'sendResponse');
+
+    // Call the handler directly with notifications/initialized method
+    cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+      id: 1.5,
+    });
+
+    // Verify no response was sent (since method is a notification)
+    sinon.assert.notCalled(sendResponseSpy);
+    // Console.log should not be called either
+    sinon.assert.notCalled(consoleLogStub);
+  });
+
+  it('handles tools/list request', async () => {
+    const logger = createTestLogger();
+    const tools = [
+      { name: 'tool1' },
+      { name: 'tool2' },
+    ];
+
+    const cmd = new MCPCommand(logger);
+    cmd.withTools(tools);
+
+    // Call the handler directly
+    cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'tools/list',
+      id: 2,
+    });
+
+    // Verify response
+    sinon.assert.calledOnce(consoleLogStub);
+    const response = JSON.parse(consoleLogStub.firstCall.args[0]);
+    assert.equal(response.id, 2);
+    assert.deepStrictEqual(response.result.tools, tools);
+  });
+
+  it('handles prompts/list request', async () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    // Call the handler directly
+    cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'prompts/list',
+      id: 3,
+    });
+
+    // Verify response
+    sinon.assert.calledOnce(consoleLogStub);
+    const response = JSON.parse(consoleLogStub.firstCall.args[0]);
+    assert.equal(response.id, 3);
+    assert.deepStrictEqual(response.result.prompts, []);
+  });
+
+  it('handles resources/list request', async () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    // Call the handler directly
+    cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'resources/list',
+      id: 4,
+    });
+
+    // Verify response
+    sinon.assert.calledOnce(consoleLogStub);
+    const response = JSON.parse(consoleLogStub.firstCall.args[0]);
+    assert.equal(response.id, 4);
+    assert.deepStrictEqual(response.result.resources, []);
+  });
+
+  it('handles ping request', async () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    // Call the handler directly
+    cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'ping',
+      id: 5,
+    });
+
+    // Verify response
+    sinon.assert.calledOnce(consoleLogStub);
+    const response = JSON.parse(consoleLogStub.firstCall.args[0]);
+    assert.equal(response.id, 5);
+    assert.deepStrictEqual(response.result, {});
+  });
+
+  it('returns method not found for unknown methods', async () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    // Call the handler directly with unknown method
+    cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'unknown',
+      id: 6,
+    });
+
+    // Verify error response
+    sinon.assert.calledOnce(consoleLogStub);
+    const response = JSON.parse(consoleLogStub.firstCall.args[0]);
+    assert.equal(response.id, 6);
+    assert.equal(response.error.code, -32601);
+    assert.equal(response.error.message, 'Method not found');
+  });
+
+  it('handles tools/call request for existing tool', async () => {
+    const logger = createTestLogger();
+
+    // Create mock tool with execute method
+    const mockExecute = sinon.stub().resolves({ success: true });
+    const tools = [
+      { name: 'test-tool', execute: mockExecute },
+    ];
+
+    const cmd = new MCPCommand(logger);
+    cmd.withTools(tools);
+
+    // Call the handler directly
+    await cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      id: 7,
+      params: {
+        name: 'test-tool',
+        arguments: { key: 'value' },
+      },
+    });
+
+    // Verify tool execute was called with arguments
+    sinon.assert.calledOnce(mockExecute);
+    sinon.assert.calledWith(mockExecute, { key: 'value' });
+
+    // Verify response
+    sinon.assert.calledOnce(consoleLogStub);
+    const response = JSON.parse(consoleLogStub.firstCall.args[0]);
+    assert.equal(response.id, 7);
+    assert.deepStrictEqual(response.result, { success: true });
+  });
+
+  it('handles tools/call request for non-existent tool', async () => {
+    const logger = createTestLogger();
+    const cmd = new MCPCommand(logger);
+
+    // Call the handler directly with non-existent tool
+    await cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      id: 8,
+      params: {
+        name: 'non-existent-tool',
+        arguments: {},
+      },
+    });
+
+    // Verify error response
+    sinon.assert.calledOnce(consoleLogStub);
+    const response = JSON.parse(consoleLogStub.firstCall.args[0]);
+    assert.equal(response.id, 8);
+    assert.equal(response.error.code, -32601);
+    assert.equal(response.error.message, "Tool 'non-existent-tool' not found");
+  });
+
+  it('handles tools/call for tool without execute method', async () => {
+    const logger = createTestLogger();
+    const tools = [
+      { name: 'invalid-tool' }, // No execute method
+    ];
+
+    const cmd = new MCPCommand(logger);
+    cmd.withTools(tools);
+
+    // Call the handler directly
+    await cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      id: 9,
+      params: {
+        name: 'invalid-tool',
+        arguments: {},
+      },
+    });
+
+    // Verify error response
+    sinon.assert.calledOnce(consoleLogStub);
+    const response = JSON.parse(consoleLogStub.firstCall.args[0]);
+    assert.equal(response.id, 9);
+    assert.equal(response.error.code, -32603);
+    assert.equal(response.error.message, "Tool 'invalid-tool' does not have an execute function");
+  });
+
+  it('handles tools/call error during execution', async () => {
+    const logger = createTestLogger();
+
+    // Create mock tool that throws error
+    const mockExecute = sinon.stub().rejects(new Error('test error'));
+    const tools = [
+      { name: 'error-tool', execute: mockExecute },
+    ];
+
+    const cmd = new MCPCommand(logger);
+    cmd.withTools(tools);
+
+    // Call the handler directly
+    await cmd.handleRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      id: 10,
+      params: {
+        name: 'error-tool',
+        arguments: {},
+      },
+    });
+
+    // Verify error response
+    sinon.assert.calledOnce(consoleLogStub);
+    const response = JSON.parse(consoleLogStub.firstCall.args[0]);
+    assert.equal(response.id, 10);
+    assert.equal(response.error.code, -32603);
+    assert.equal(response.error.message, 'Error executing tool: test error');
+  });
+
+  it('initializes readline in run() method', async () => {
+    const logger = createTestLogger();
+
+    // Mock readline interface
+    const lineEmitter = new EventEmitter();
+    const createInterfaceStub = sinon.stub().returns(lineEmitter);
+
+    // Replace readline with our mock
+    const MockedCommand = await esmock('../src/mcp.cmd.js', {
+      readline: {
+        createInterface: createInterfaceStub,
+      },
+    });
+
+    // Create command instance
+    const mockedCmd = new MockedCommand(logger);
+
+    // Start the command
+    mockedCmd.run();
+
+    // Verify readline interface was created with expected config
+    sinon.assert.calledOnce(createInterfaceStub);
+    sinon.assert.calledWith(createInterfaceStub, {
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    });
+  });
+
+  it('handles invalid JSON in the run method', async () => {
+    const logger = createTestLogger();
+    const loggerErrorSpy = sinon.spy(logger, 'error');
+
+    // Mock readline interface
+    const lineEmitter = new EventEmitter();
+    const createInterfaceStub = sinon.stub().returns(lineEmitter);
+
+    // Replace readline with our mock
+    const MockedCommand = await esmock('../src/mcp.cmd.js', {
+      readline: {
+        createInterface: createInterfaceStub,
+      },
+    });
+
+    // Create command instance with a spy for sendErrorResponse
+    const mockedCmd = new MockedCommand(logger);
+    const sendErrorResponseSpy = sinon.spy(mockedCmd, 'sendErrorResponse');
+
+    // Start the command
+    await mockedCmd.run();
+
+    // Emit invalid JSON to trigger error handling
+    lineEmitter.emit('line', '{invalid:json}');
+
+    // Check that error was logged
+    sinon.assert.called(loggerErrorSpy);
+    sinon.assert.calledWithMatch(loggerErrorSpy, /Error processing request/);
+
+    // Verify sendErrorResponse was called with correct error code
+    sinon.assert.called(sendErrorResponseSpy);
+    sinon.assert.calledWith(sendErrorResponseSpy, -32700, 'Parse error', null);
+  });
+});

--- a/test/mcp-logger.test.js
+++ b/test/mcp-logger.test.js
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import {
+  createInMemoryLogger, getLogs, createLoggerFactory, resetLogs,
+} from '../src/mcp-logger.js';
+
+describe('MCP Logger', () => {
+  beforeEach(() => {
+    // Clear logs between tests using resetLogs
+    resetLogs();
+  });
+
+  it('creates a logger with default category', () => {
+    const logger = createInMemoryLogger();
+    assert.strictEqual(logger.category, 'mcp');
+  });
+
+  it('creates a logger with custom category', () => {
+    const logger = createInMemoryLogger('test');
+    assert.strictEqual(logger.category, 'test');
+  });
+
+  it('logs messages with different levels', () => {
+    const logger = createInMemoryLogger('test');
+    logger.debug('Debug message');
+    logger.info('Info message');
+    logger.warn('Warning message');
+    logger.error('Error message');
+
+    const logs = getLogs();
+    assert.strictEqual(logs.length, 4);
+
+    assert.strictEqual(logs[0].level, 'debug');
+    assert.strictEqual(logs[0].message, 'Debug message');
+    assert.strictEqual(logs[0].context.category, 'test');
+
+    assert.strictEqual(logs[1].level, 'info');
+    assert.strictEqual(logs[1].message, 'Info message');
+
+    assert.strictEqual(logs[2].level, 'warn');
+    assert.strictEqual(logs[2].message, 'Warning message');
+
+    assert.strictEqual(logs[3].level, 'error');
+    assert.strictEqual(logs[3].message, 'Error message');
+  });
+
+  it('logs messages with additional context', () => {
+    const logger = createInMemoryLogger('test');
+
+    logger.info('Message with context', { user: 'testuser', id: 123 });
+
+    const logs = getLogs();
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].message, 'Message with context');
+    assert.strictEqual(logs[0].context.user, 'testuser');
+    assert.strictEqual(logs[0].context.id, 123);
+    assert.strictEqual(logs[0].context.category, 'test');
+  });
+
+  it('does not override existing category in context', () => {
+    const logger = createInMemoryLogger('test');
+
+    logger.info('Message with custom category', { category: 'custom' });
+
+    const logs = getLogs();
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].context.category, 'custom');
+  });
+
+  it('limits the number of stored logs', () => {
+    const logger = createInMemoryLogger('test');
+
+    // Generate more logs than the limit (1000 is the default in the implementation)
+    for (let i = 0; i < 1100; i += 1) {
+      logger.info(`Log message ${i}`);
+    }
+
+    const logs = getLogs(1100);
+    assert.strictEqual(logs.length, 1000); // Only the last 1000 should be kept
+    assert.strictEqual(logs[0].message, 'Log message 100'); // First log should be 100
+    assert.strictEqual(logs[999].message, 'Log message 1099'); // Last log should be 1099
+  });
+
+  it('filters logs by text', () => {
+    const logger = createInMemoryLogger('test');
+
+    logger.info('apple message');
+    logger.info('banana message');
+    logger.info('apple and orange');
+
+    const logs = getLogs(10, 'apple');
+    assert.strictEqual(logs.length, 2);
+    assert.strictEqual(logs[0].message, 'apple message');
+    assert.strictEqual(logs[1].message, 'apple and orange');
+  });
+
+  it('filters logs by context', () => {
+    const logger = createInMemoryLogger('test');
+
+    logger.info('message 1', { fruit: 'apple' });
+    logger.info('message 2', { fruit: 'banana' });
+    logger.info('message 3', { fruit: 'apple' });
+
+    const logs = getLogs(10, 'apple');
+    assert.strictEqual(logs.length, 2);
+    assert.strictEqual(logs[0].message, 'message 1');
+    assert.strictEqual(logs[1].message, 'message 3');
+  });
+
+  it('filters logs by level', () => {
+    const logger = createInMemoryLogger('test');
+
+    logger.debug('debug message');
+    logger.info('info message');
+
+    const logs = getLogs(10, 'debug');
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].message, 'debug message');
+  });
+
+  it('limits the number of returned logs', () => {
+    const logger = createInMemoryLogger('test');
+
+    logger.info('message 1');
+    logger.info('message 2');
+    logger.info('message 3');
+
+    const logs = getLogs(2);
+    assert.strictEqual(logs.length, 2);
+    assert.strictEqual(logs[0].message, 'message 2');
+    assert.strictEqual(logs[1].message, 'message 3');
+  });
+
+  it('creates a logger factory', () => {
+    const factory = createLoggerFactory();
+    const logger = factory('custom');
+
+    assert.strictEqual(logger.category, 'custom');
+
+    logger.info('Factory created logger');
+
+    const logs = getLogs();
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].message, 'Factory created logger');
+    assert.strictEqual(logs[0].context.category, 'custom');
+  });
+
+  it('returns timestamps with logs', () => {
+    const logger = createInMemoryLogger();
+
+    logger.info('Test timestamp');
+
+    const logs = getLogs();
+    assert.strictEqual(logs.length, 1);
+    assert(logs[0].timestamp); // Ensure timestamp exists
+    assert(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/.test(logs[0].timestamp)); // ISO format
+  });
+
+  it('filters logs by seconds', () => {
+    const logger = createInMemoryLogger('test');
+
+    // Create a log entry with a timestamp that is 30 seconds old
+    const oldDate = new Date(Date.now() - 30000);
+
+    // Create an old message with explicit timestamp
+    logger.info('Old message');
+
+    // Manually edit timestamps - we'll directly add it back to the logs with proper timestamp
+    resetLogs(); // Clear logs
+
+    // Add back the old message with modified timestamp
+    logger.info('Old message');
+    const currentLogs = getLogs();
+    // We need to modify the global LOG_BUFFER directly
+    // This is a hack for testing, not something we'd normally do
+    // Get a reference to the last log entry and modify its timestamp
+    currentLogs[0].timestamp = oldDate.toISOString();
+
+    // Now log a new message
+    logger.info('New message');
+
+    // Filter logs from the last 10 seconds
+    const recentLogs = getLogs(10, null, 10);
+    assert.strictEqual(recentLogs.length, 1);
+    assert.strictEqual(recentLogs[0].message, 'New message');
+
+    // Get all logs without time filtering
+    const allLogsAgain = getLogs();
+    assert.strictEqual(allLogsAgain.length, 2);
+  });
+
+  it('filters logs by log levels', () => {
+    const logger = createInMemoryLogger('test');
+
+    logger.debug('Debug message');
+    logger.info('Info message');
+    logger.warn('Warning message');
+    logger.error('Error message');
+
+    // Filter only error and warn levels
+    const highLevelLogs = getLogs(10, null, null, ['error', 'warn']);
+    assert.strictEqual(highLevelLogs.length, 2);
+    assert.strictEqual(highLevelLogs[0].level, 'warn');
+    assert.strictEqual(highLevelLogs[1].level, 'error');
+
+    // Filter only debug level
+    const debugLogs = getLogs(10, null, null, ['debug']);
+    assert.strictEqual(debugLogs.length, 1);
+    assert.strictEqual(debugLogs[0].level, 'debug');
+  });
+
+  it('combines all filters - text, seconds, and levels', () => {
+    const logger = createInMemoryLogger('test');
+
+    // Create logs with different timestamps and levels
+    const oldDate = new Date(Date.now() - 30000);
+
+    // Create test logs
+    logger.debug('Old debug apple');
+    logger.info('Old info apple');
+    logger.warn('Old warn banana');
+    logger.error('Old error apple');
+
+    // Clear logs and add back with modified timestamps
+    resetLogs();
+
+    // Add the old logs back with modified timestamps
+    logger.debug('Old debug apple');
+    logger.info('Old info apple');
+    logger.warn('Old warn banana');
+    logger.error('Old error apple');
+
+    // Get the logs and modify their timestamps
+    const currentLogs = getLogs();
+    // Update timestamps for all logs
+    for (let i = 0; i < currentLogs.length; i += 1) {
+      currentLogs[i].timestamp = oldDate.toISOString();
+    }
+
+    // Add new logs
+    logger.debug('New debug apple');
+    logger.info('New info banana');
+    logger.warn('New warn apple');
+    logger.error('New error banana');
+
+    // Filter: recent logs (within 10s), containing 'apple', only warn/error levels
+    const filteredLogs = getLogs(10, 'apple', 10, ['warn', 'error']);
+
+    assert.strictEqual(filteredLogs.length, 1);
+    assert.strictEqual(filteredLogs[0].message, 'New warn apple');
+    assert.strictEqual(filteredLogs[0].level, 'warn');
+  });
+});

--- a/test/mcp-tools-logs.test.js
+++ b/test/mcp-tools-logs.test.js
@@ -95,6 +95,26 @@ describe('MCP Tools - logs', () => {
     assert.strictEqual(parsedContent[0].message, 'Test log message');
   });
 
+  it('handles empty log entries by returning a default message', async () => {
+    // Mock getLogs to return null, which would make JSON.stringify(null) be 'null' (truthy)
+    // but we need to test the case where the JSON string is falsy
+    getLogsStub.returns(null);
+
+    // Create a special stub for JSON.stringify that returns a falsy value
+    const originalStringify = JSON.stringify;
+    JSON.stringify = sinon.stub().returns('');
+
+    const result = await logsTool.default.execute({});
+
+    // Restore JSON.stringify
+    JSON.stringify = originalStringify;
+
+    assert.strictEqual(result.isError, false);
+    assert.ok(Array.isArray(result.content));
+    assert.strictEqual(result.content[0].type, 'text');
+    assert.strictEqual(result.content[0].text, 'No log entries found.');
+  });
+
   it('handles errors gracefully', async () => {
     const error = new Error('Test error');
     getLogsStub.throws(error);

--- a/test/mcp-tools-logs.test.js
+++ b/test/mcp-tools-logs.test.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+describe('MCP Tools - logs', () => {
+  let getLogsStub;
+  let logsTool;
+
+  beforeEach(async () => {
+    // Sample log data to return from the stub
+    const sampleLogs = [
+      {
+        timestamp: '2023-04-24T00:00:00.000Z',
+        level: 'info',
+        message: 'Test log message',
+        context: { category: 'test' },
+      },
+    ];
+
+    // Create stub for getLogs function
+    getLogsStub = sinon.stub().returns(sampleLogs);
+
+    // Mock the dependencies
+    logsTool = await esmock('../src/tools/logs.js', {
+      '../src/mcp-logger.js': { getLogs: getLogsStub },
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('has the correct name and description', () => {
+    assert.strictEqual(logsTool.default.name, 'logs');
+    assert.ok(logsTool.default.description.includes('Retrieve the last log entries'));
+  });
+
+  it('has the expected input schema', () => {
+    const schema = logsTool.default.inputSchema;
+    assert.strictEqual(schema.type, 'object');
+
+    // Check presence of expected properties
+    const expectedProps = ['lines', 'seconds', 'filter', 'levels'];
+    expectedProps.forEach((prop) => {
+      assert.ok(schema.properties[prop], `Schema should include ${prop} property`);
+    });
+
+    // Check defaults for some properties
+    assert.strictEqual(schema.properties.lines.default, 20);
+    assert.deepStrictEqual(schema.properties.levels.default, ['info', 'warn', 'error']);
+  });
+
+  it('uses default values when no args provided', async () => {
+    await logsTool.default.execute({});
+
+    sinon.assert.calledWith(getLogsStub, 20, '', null, null);
+  });
+
+  it('passes arguments to getLogs function', async () => {
+    const args = {
+      lines: 50,
+      filter: 'error',
+      seconds: 60,
+      levels: ['debug', 'error'],
+    };
+
+    await logsTool.default.execute(args);
+
+    sinon.assert.calledWith(getLogsStub, 50, 'error', 60, ['debug', 'error']);
+  });
+
+  it('returns log entries as JSON in the response', async () => {
+    const result = await logsTool.default.execute({});
+
+    assert.strictEqual(result.isError, false);
+    assert.ok(Array.isArray(result.content));
+    assert.strictEqual(result.content[0].type, 'text');
+
+    // Check that the response contains JSON
+    const parsedContent = JSON.parse(result.content[0].text);
+    assert.ok(Array.isArray(parsedContent));
+    assert.strictEqual(parsedContent[0].message, 'Test log message');
+  });
+
+  it('handles errors gracefully', async () => {
+    const error = new Error('Test error');
+    getLogsStub.throws(error);
+
+    const result = await logsTool.default.execute({});
+
+    assert.strictEqual(result.isError, true);
+    assert.ok(result.content[0].text.includes('Test error'));
+  });
+});

--- a/test/mcp-tools-stop.test.js
+++ b/test/mcp-tools-stop.test.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+describe('MCP Tools - stop', () => {
+  // Stubs for dependencies
+  let mockLoggerInstance;
+  let createLoggerStub;
+  let stopTool;
+
+  beforeEach(async () => {
+    // Create mock logger with error method
+    mockLoggerInstance = {
+      error: sinon.stub(),
+      info: sinon.stub(),
+      debug: sinon.stub(),
+      warn: sinon.stub(),
+    };
+
+    // Create stub for createInMemoryLogger
+    createLoggerStub = sinon.stub().returns(mockLoggerInstance);
+
+    // Mock the dependencies
+    const stopModule = await esmock.p('../src/tools/stop.js', {
+      '../src/log-common.js': { getOrCreateLogger: createLoggerStub },
+    });
+
+    // Get a reference to the tool
+    stopTool = stopModule.default;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('has the correct name and description', () => {
+    assert.strictEqual(stopTool.name, 'stop');
+    assert.ok(stopTool.description.includes('Stop a running AEM development server'));
+  });
+
+  it('has the expected input schema', () => {
+    const schema = stopTool.inputSchema;
+    assert.strictEqual(schema.type, 'object');
+
+    // Check presence of expected properties
+    const expectedProps = ['port', 'all'];
+    expectedProps.forEach((prop) => {
+      assert.ok(schema.properties[prop], `Schema should include ${prop} property`);
+    });
+
+    // Check defaults for some properties
+    assert.strictEqual(schema.properties.port.default, 3000);
+    assert.strictEqual(schema.properties.all.default, true);
+  });
+
+  it('handles request to stop a specific server', async () => {
+    const result = await stopTool.execute({ port: 3000, all: false });
+
+    // Should be successful and have a response
+    assert.strictEqual(result.isError, false);
+    assert.ok(Array.isArray(result.content));
+    assert.ok(result.content.length > 0);
+    assert.strictEqual(result.content[0].type, 'text');
+  });
+
+  it('handles request to stop all servers', async () => {
+    const result = await stopTool.execute({ all: true });
+
+    // Should be successful and have a response
+    assert.strictEqual(result.isError, false);
+    assert.ok(Array.isArray(result.content));
+    assert.ok(result.content.length > 0);
+    assert.strictEqual(result.content[0].type, 'text');
+  });
+
+  it('creates a logger when executed', async () => {
+    await stopTool.execute({});
+
+    // Should create a logger
+    sinon.assert.called(createLoggerStub);
+  });
+});

--- a/test/mcp-tools-stop.test.js
+++ b/test/mcp-tools-stop.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -11,85 +11,255 @@
  */
 
 /* eslint-env mocha */
+
 import assert from 'assert';
-import sinon from 'sinon';
 import esmock from 'esmock';
 
-describe('MCP Tools - stop', () => {
-  // Stubs for dependencies
-  let mockLoggerInstance;
-  let createLoggerStub;
-  let stopTool;
+// Mock server implementation
+class MockServer {
+  constructor(port) {
+    this.port = port;
+    this.stopped = false;
+  }
 
+  async doStop() {
+    if (this.failOnStop) {
+      throw new Error('Intentional stop failure');
+    }
+    this.stopped = true;
+    return true;
+  }
+
+  setFailOnStop() {
+    this.failOnStop = true;
+  }
+}
+
+describe('AEM MCP Tools - stop', () => {
+  let logMessages;
+  let stopTool;
+  let registerServer;
+  let mockLogger;
+
+  // Set up mocks before each test
   beforeEach(async () => {
-    // Create mock logger with error method
-    mockLoggerInstance = {
-      error: sinon.stub(),
-      info: sinon.stub(),
-      debug: sinon.stub(),
-      warn: sinon.stub(),
+    logMessages = [];
+    mockLogger = {
+      info: (msg) => { logMessages.push(['info', msg]); },
+      error: (msg) => { logMessages.push(['error', msg]); },
     };
 
-    // Create stub for createInMemoryLogger
-    createLoggerStub = sinon.stub().returns(mockLoggerInstance);
+    // Mock the log-common module
+    const mockLogCommon = {
+      getOrCreateLogger: () => mockLogger,
+    };
 
-    // Mock the dependencies
-    const stopModule = await esmock.p('../src/tools/stop.js', {
-      '../src/log-common.js': { getOrCreateLogger: createLoggerStub },
+    // Use esmock to mock the dependencies
+    const stopModule = await esmock('../src/tools/stop.js', {
+      '../src/log-common.js': mockLogCommon,
     });
 
-    // Get a reference to the tool
+    // Get the exports from the mocked module
     stopTool = stopModule.default;
+    registerServer = stopModule.registerServer;
+
+    // Clean up between tests
+    if (stopTool) {
+      await stopTool.execute({ all: true }).catch(() => { });
+    }
   });
 
-  afterEach(() => {
-    sinon.restore();
-  });
-
-  it('has the correct name and description', () => {
+  it('has the right name and description', () => {
     assert.strictEqual(stopTool.name, 'stop');
-    assert.ok(stopTool.description.includes('Stop a running AEM development server'));
+    assert.ok(stopTool.description);
   });
 
-  it('has the expected input schema', () => {
-    const schema = stopTool.inputSchema;
-    assert.strictEqual(schema.type, 'object');
+  it('has an input schema with port and all properties', () => {
+    assert.ok(stopTool.inputSchema);
+    assert.strictEqual(stopTool.inputSchema.type, 'object');
+    assert.ok(stopTool.inputSchema.properties.port);
+    assert.ok(stopTool.inputSchema.properties.all);
 
-    // Check presence of expected properties
-    const expectedProps = ['port', 'all'];
-    expectedProps.forEach((prop) => {
-      assert.ok(schema.properties[prop], `Schema should include ${prop} property`);
-    });
-
-    // Check defaults for some properties
-    assert.strictEqual(schema.properties.port.default, 3000);
-    assert.strictEqual(schema.properties.all.default, true);
+    assert.strictEqual(stopTool.inputSchema.properties.port.default, 3000);
+    assert.strictEqual(stopTool.inputSchema.properties.all.default, true);
   });
 
-  it('handles request to stop a specific server', async () => {
-    const result = await stopTool.execute({ port: 3000, all: false });
+  it('registers a server', async () => {
+    const mockServer = new MockServer(4000);
+    registerServer(4000, mockServer);
 
-    // Should be successful and have a response
+    const result = await stopTool.execute({ port: 4000, all: false });
+
     assert.strictEqual(result.isError, false);
-    assert.ok(Array.isArray(result.content));
-    assert.ok(result.content.length > 0);
-    assert.strictEqual(result.content[0].type, 'text');
+    assert.strictEqual(result.content[0].text, 'AEM development server on port 4000 stopped.');
+    assert.strictEqual(mockServer.stopped, true);
   });
 
-  it('handles request to stop all servers', async () => {
+  it('returns message when no servers are running', async () => {
     const result = await stopTool.execute({ all: true });
 
-    // Should be successful and have a response
     assert.strictEqual(result.isError, false);
-    assert.ok(Array.isArray(result.content));
-    assert.ok(result.content.length > 0);
-    assert.strictEqual(result.content[0].type, 'text');
+    assert.strictEqual(result.content[0].text, 'No running AEM servers found.');
   });
 
-  it('creates a logger when executed', async () => {
-    await stopTool.execute({});
+  it('returns message when specified server is not found', async () => {
+    const result = await stopTool.execute({ port: 9999, all: false });
 
-    // Should create a logger
-    sinon.assert.called(createLoggerStub);
+    assert.strictEqual(result.isError, false);
+    assert.strictEqual(result.content[0].text, 'No AEM server running on port 9999.');
+  });
+
+  it('stops multiple servers when all is true', async () => {
+    const mockServer1 = new MockServer(3000);
+    const mockServer2 = new MockServer(4000);
+
+    registerServer(3000, mockServer1);
+    registerServer(4000, mockServer2);
+
+    const result = await stopTool.execute({ all: true });
+
+    assert.strictEqual(result.isError, false);
+    assert.strictEqual(result.content[0].text, 'Stopped 2 AEM server(s).');
+    assert.strictEqual(mockServer1.stopped, true);
+    assert.strictEqual(mockServer2.stopped, true);
+  });
+
+  it('uses port default if not provided', async () => {
+    const mockServer = new MockServer(3000);
+    registerServer(3000, mockServer);
+
+    const result = await stopTool.execute({ all: false });
+
+    assert.strictEqual(result.isError, false);
+    assert.strictEqual(result.content[0].text, 'AEM development server on port 3000 stopped.');
+    assert.strictEqual(mockServer.stopped, true);
+  });
+
+  it('handles errors when stopping a server', async () => {
+    const mockServer = new MockServer(5000);
+    mockServer.setFailOnStop();
+    registerServer(5000, mockServer);
+
+    const result = await stopTool.execute({ port: 5000, all: false });
+
+    assert.strictEqual(result.isError, true);
+    assert.ok(result.content[0].text.includes('Error stopping AEM server'));
+  });
+
+  it('logs errors but continues when stopping multiple servers', async () => {
+    // Clear log messages to ensure we only capture relevant ones
+    logMessages = [];
+
+    const mockServer1 = new MockServer(3000);
+    const mockServer2 = new MockServer(4000);
+    mockServer2.setFailOnStop();
+    const mockServer3 = new MockServer(5000);
+
+    registerServer(3000, mockServer1);
+    registerServer(4000, mockServer2);
+    registerServer(5000, mockServer3);
+
+    const result = await stopTool.execute({ all: true });
+
+    assert.strictEqual(result.isError, false);
+    assert.strictEqual(result.content[0].text, 'Stopped 2 AEM server(s).');
+    assert.strictEqual(mockServer1.stopped, true);
+    assert.strictEqual(mockServer3.stopped, true);
+
+    // Verify an error was logged
+    assert.ok(logMessages.length > 0, 'Expected log messages');
+    assert.ok(
+      logMessages.some(([level]) => level === 'error'),
+      'Expected at least one error log message',
+    );
+  });
+
+  it('handles string port values correctly', async () => {
+    const mockServer = new MockServer(6000);
+    registerServer('6000', mockServer);
+
+    const result = await stopTool.execute({ port: 6000, all: false });
+
+    assert.strictEqual(result.isError, false);
+    assert.strictEqual(result.content[0].text, 'AEM development server on port 6000 stopped.');
+    assert.strictEqual(mockServer.stopped, true);
+  });
+
+  // Additional tests to improve coverage
+  it('properly handles server being null or undefined', async () => {
+    // Forcibly add a null server to test error handling
+    registerServer('7000', null);
+
+    const result = await stopTool.execute({ all: true });
+
+    // Should not fail and should return message about stopping 0 servers
+    assert.strictEqual(result.isError, false);
+    assert.strictEqual(result.content[0].text, 'Stopped 0 AEM server(s).');
+  });
+
+  it('handles outer try-catch block by simulating a complete failure', async () => {
+    // Create a server with a doStop method that throws in an unexpected way
+    const badMockServer = new MockServer(8000);
+
+    // Override the doStop method to throw unexpectedly
+    badMockServer.doStop = async () => {
+      throw new Error('Catastrophic failure');
+    };
+
+    registerServer(8000, badMockServer);
+
+    const result = await stopTool.execute({ port: 8000, all: false });
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.content[0].text, 'Error stopping AEM server: Catastrophic failure');
+  });
+
+  it('handles when runningServers map has entries but all fail to stop', async () => {
+    // Clear log messages
+    logMessages = [];
+
+    const failServer1 = new MockServer(9001);
+    const failServer2 = new MockServer(9002);
+
+    failServer1.setFailOnStop();
+    failServer2.setFailOnStop();
+
+    registerServer('9001', failServer1);
+    registerServer('9002', failServer2);
+
+    const result = await stopTool.execute({ all: true });
+
+    // Should not be an error even though all servers failed to stop
+    assert.strictEqual(result.isError, false);
+    assert.strictEqual(result.content[0].text, 'Stopped 0 AEM server(s).');
+
+    // Check for error logs
+    assert.ok(logMessages.length > 0, 'Expected log messages');
+    assert.ok(
+      logMessages.some(([level]) => level === 'error'),
+      'Expected at least one error log message',
+    );
+  });
+
+  it('handles case where runningServers has a port but server is undefined', async () => {
+    // Register a server but then make it undefined
+    registerServer(9003, undefined);
+
+    const result = await stopTool.execute({ port: 9003, all: false });
+
+    // Should report no server running even though port exists in map
+    assert.strictEqual(result.isError, false);
+    assert.strictEqual(result.content[0].text, 'No AEM server running on port 9003.');
+  });
+
+  it('properly deletes servers from the map after stopping them', async () => {
+    const mockServer = new MockServer(9004);
+    registerServer(9004, mockServer);
+
+    await stopTool.execute({ port: 9004, all: false });
+
+    // Try to stop the same server again - should report not found
+    const secondResult = await stopTool.execute({ port: 9004, all: false });
+    assert.strictEqual(secondResult.content[0].text, 'No AEM server running on port 9004.');
   });
 });

--- a/test/mcp-tools-up.test.js
+++ b/test/mcp-tools-up.test.js
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+describe('MCP Tools - up', () => {
+  // Stubs for dependencies
+  let runStub;
+  let mockUpCommandImpl;
+  let upCommandStub;
+  let registerServerStub;
+  let mockLoggerInstance;
+  let createLoggerStub;
+  let upTool;
+
+  beforeEach(async () => {
+    // Create stubs
+    runStub = sinon.stub().resolves();
+
+    // Create a mock UpCommandImpl with chainable methods
+    mockUpCommandImpl = {
+      withHttpPort: sinon.stub().returnsThis(),
+      withBindAddr: sinon.stub().returnsThis(),
+      withOpen: sinon.stub().returnsThis(),
+      withTLS: sinon.stub().returnsThis(),
+      withLiveReload: sinon.stub().returnsThis(),
+      withUrl: sinon.stub().returnsThis(),
+      withSiteToken: sinon.stub().returnsThis(),
+      withAllowInsecure: sinon.stub().returnsThis(),
+      withPrintIndex: sinon.stub().returnsThis(),
+      run: runStub,
+    };
+
+    // Create stub for UpCommandImpl constructor
+    upCommandStub = sinon.stub().returns(mockUpCommandImpl);
+
+    // Create stub for registerServer
+    registerServerStub = sinon.stub();
+
+    // Create mock logger with error method
+    mockLoggerInstance = {
+      error: sinon.stub(),
+      info: sinon.stub(),
+      debug: sinon.stub(),
+      warn: sinon.stub(),
+    };
+
+    // Create stub for createInMemoryLogger
+    createLoggerStub = sinon.stub().returns(mockLoggerInstance);
+
+    // Mock the dependencies
+    upTool = await esmock('../src/tools/up.js', {
+      '../src/up.cmd.js': { default: upCommandStub },
+      '../src/mcp-logger.js': { createInMemoryLogger: createLoggerStub },
+      '../src/tools/stop.js': { registerServer: registerServerStub },
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('has the correct name and description', () => {
+    assert.strictEqual(upTool.default.name, 'up');
+    assert.ok(upTool.default.description.includes('Run an AEM development server'));
+  });
+
+  it('has the expected input schema', () => {
+    const schema = upTool.default.inputSchema;
+    assert.strictEqual(schema.type, 'object');
+
+    // Check presence of expected properties
+    const expectedProps = ['port', 'addr', 'open', 'livereload', 'url', 'tlsCert', 'tlsKey'];
+    expectedProps.forEach((prop) => {
+      assert.ok(schema.properties[prop], `Schema should include ${prop} property`);
+    });
+
+    // Check defaults for some properties
+    assert.strictEqual(schema.properties.port.default, 3000);
+    assert.strictEqual(schema.properties.livereload.default, true);
+  });
+
+  it('creates a logger with correct category', async () => {
+    await upTool.default.execute({});
+    sinon.assert.calledWith(createLoggerStub, 'up');
+  });
+
+  it('configures server with default values', async () => {
+    await upTool.default.execute({});
+
+    sinon.assert.calledWith(mockUpCommandImpl.withHttpPort, 3000);
+    sinon.assert.calledWith(mockUpCommandImpl.withBindAddr, '127.0.0.1');
+    sinon.assert.calledWith(mockUpCommandImpl.withOpen, false);
+    sinon.assert.calledWith(mockUpCommandImpl.withLiveReload, true);
+  });
+
+  it('configures server with custom values', async () => {
+    const args = {
+      port: '8080',
+      addr: '0.0.0.0',
+      open: '/content',
+      livereload: false,
+      url: 'https://example.com',
+      tlsCert: '/path/to/cert.pem',
+      tlsKey: '/path/to/key.pem',
+      siteToken: 'token123',
+      allowInsecure: true,
+      printIndex: true,
+    };
+
+    await upTool.default.execute(args);
+
+    sinon.assert.calledWith(mockUpCommandImpl.withHttpPort, 8080);
+    sinon.assert.calledWith(mockUpCommandImpl.withBindAddr, '0.0.0.0');
+    sinon.assert.calledWith(mockUpCommandImpl.withOpen, '/content');
+    sinon.assert.calledWith(mockUpCommandImpl.withTLS, '/path/to/key.pem', '/path/to/cert.pem');
+    sinon.assert.calledWith(mockUpCommandImpl.withLiveReload, false);
+    sinon.assert.calledWith(mockUpCommandImpl.withUrl, 'https://example.com');
+    sinon.assert.calledWith(mockUpCommandImpl.withSiteToken, 'token123');
+    sinon.assert.calledWith(mockUpCommandImpl.withAllowInsecure, true);
+    sinon.assert.calledWith(mockUpCommandImpl.withPrintIndex, true);
+  });
+
+  it('parses port number from string', async () => {
+    await upTool.default.execute({ port: '4200' });
+    sinon.assert.calledWith(mockUpCommandImpl.withHttpPort, 4200);
+  });
+
+  it('registers the server instance for later stopping', async () => {
+    await upTool.default.execute({ port: 5000 });
+    sinon.assert.calledWith(registerServerStub, 5000, mockUpCommandImpl);
+  });
+
+  it('runs the server without blocking', async () => {
+    await upTool.default.execute({});
+    sinon.assert.called(runStub);
+  });
+
+  it('returns success message with port information', async () => {
+    const result = await upTool.default.execute({ port: 5000 });
+
+    assert.strictEqual(result.isError, false);
+    assert.ok(Array.isArray(result.content));
+    assert.strictEqual(result.content[0].type, 'text');
+    assert.ok(result.content[0].text.includes('5000'));
+  });
+
+  it('handles errors during execution', async () => {
+    const error = new Error('Test error');
+    upCommandStub.throws(error);
+
+    const result = await upTool.default.execute({});
+
+    assert.strictEqual(result.isError, true);
+    assert.ok(result.content[0].text.includes('Test error'));
+  });
+
+  it('handles errors during server start', async () => {
+    const error = new Error('Run error');
+    runStub.rejects(error);
+
+    await upTool.default.execute({});
+    sinon.assert.calledWith(mockLoggerInstance.error, sinon.match(/Run error/));
+  });
+});


### PR DESCRIPTION
- **feat(mcp): add MCP command and logging tools**
- **feat(mcp-logger): add resetLogs function and enhance logging tests**
- **fix(stop-tool): handle string port values and improve error handling**
- **test(mcp): bring test coverage up to 100%**
- **docs(README): add section on using AEM as an MCP server**

This PR adds a small MCP server that can be used to start, stop, and retrieve logs from a local
AEM development server. Check the readme for details on running it, although to run it from a this
branch, you'll need `npx github:adobe/helix-cli#mcp mcp`. Yep, that's `mcp` twice.
