### PR TITLE
fix: make logger compatible with helix-log v7.0.0

### DIFF
--- a/src/log-common.js
+++ b/src/log-common.js
@@ -100,21 +100,21 @@ export function getOrCreateLogger(config = 'cli') {
     ? config.logFile
     : ['-', (config && config.logFile) || path.join(logsDir, `${categ}-server.log`)];
 
-  const loggers = new Map();
+  const loggers = {};
   logFiles.forEach((logFile) => {
-    const name = loggers.has('default') ? logFile : 'default';
+    const name = loggers.default ? logFile : 'default';
     if (logFile === '-') {
-      loggers.set(name, new ConsoleLogger({
+      loggers[name] = new ConsoleLogger({
         filter: categ === 'cli' ? suppressProgress : filterProgress,
         level,
         formatter: categoryAwareMessageFormatConsole,
-      }));
+      });
     } else {
       fs.ensureDirSync(path.dirname(logFile));
-      loggers.set(name, new FileLogger(logFile, {
+      loggers[name] = new FileLogger(logFile, {
         level: 'debug',
         formatter: /\.json/.test(logFile) ? messageFormatJsonString : messageFormatTechnical,
-      }));
+      });
     }
   });
 


### PR DESCRIPTION
**SUMMARY**
This PR updates logger creation from `Map` to plain objects to work with `@adobe/helix-log@7.0.0`

Since [@adobe/aem-cli@16.10.40](https://github.com/adobe/helix-cli/releases/tag/v16.10.40), which updated `helix-log` to `7.0.0`, no logs appear in the terminal when running `aem up`. Dev server runs silently without outputting anything to console.

When [this line](https://github.com/adobe/helix-log/blob/main/src/log.js#L667) changed from `dict(loggers)` to `Object.entries(loggers)`, it impacted `Map` support which is what `aem-cli` was using to create loggers. 

**TESTING**
- Tested on multiple projects with `node v24.6.0`

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
