### PR TITLE
fix(2576): provide a way to dump all headers

### DIFF
--- a/src/import.cmd.js
+++ b/src/import.cmd.js
@@ -24,6 +24,7 @@ export default class ImportCommand extends AbstractServerCommand {
     super(logger);
     this._importerSubPath = 'tools/importer';
     this._allowInsecure = true;
+    this._dumpHeaders = false;
   }
 
   withAllowInsecure(value) {
@@ -56,6 +57,11 @@ export default class ImportCommand extends AbstractServerCommand {
 
   withHeadersFile(value) {
     this._headersFile = value;
+    return this;
+  }
+
+  withDumpHeaders(value) {
+    this._dumpHeaders = value;
     return this;
   }
 
@@ -136,7 +142,8 @@ export default class ImportCommand extends AbstractServerCommand {
       .withLogger(this._logger)
       .withKill(this._kill)
       .withAllowInsecure(this._allowInsecure)
-      .withHeadersFile(this._headersFile);
+      .withHeadersFile(this._headersFile)
+      .withDumpHeaders(this._dumpHeaders);
     this.log.info(chalk`{yellow     ___    ________  ___                                __}`);
     this.log.info(chalk`{yellow    /   |  / ____/  |/  /  (_)___ ___  ____  ____  _____/ /____  _____}`);
     this.log.info(chalk`{yellow   / /| | / __/ / /|_/ /  / / __ \`__ \\/ __ \\/ __ \\/ ___/ __/ _ \\/ ___/}`);

--- a/src/import.js
+++ b/src/import.js
@@ -80,6 +80,12 @@ export default function up() {
           type: 'string',
           default: undefined,
         })
+        .option('dump-headers', {
+          alias: 'dumpHeaders',
+          describe: 'Dump request headers to console for debugging',
+          type: 'boolean',
+          default: false,
+        })
         .group(['port', 'addr', 'stop-other', 'tls-cert', 'tls-key'], 'Server options')
         .option('cache', {
           describe: 'Path to local folder to cache the responses',
@@ -118,6 +124,7 @@ export default function up() {
         .withSkipUI(argv.skipUI)
         .withUIRepo(argv.uiRepo)
         .withHeadersFile(argv.headersFile)
+        .withDumpHeaders(argv.dumpHeaders)
         .run();
     },
   };

--- a/src/server/HelixImportProject.js
+++ b/src/server/HelixImportProject.js
@@ -18,6 +18,7 @@ export class HelixImportProject extends BaseProject {
     super(HelixImportServer);
 
     this._allowInsecure = true;
+    this._dumpHeaders = false;
   }
 
   withAllowInsecure(value) {
@@ -40,6 +41,15 @@ export class HelixImportProject extends BaseProject {
 
   get cliHeaders() {
     return this._cliHeaders;
+  }
+
+  withDumpHeaders(value) {
+    this._dumpHeaders = value;
+    return this;
+  }
+
+  get dumpHeaders() {
+    return this._dumpHeaders;
   }
 
   async start() {

--- a/src/server/HelixImportServer.js
+++ b/src/server/HelixImportServer.js
@@ -108,6 +108,17 @@ export class HelixImportServer extends BaseServer {
     delete headers['accept-encoding'];
     await this._updateHeaders(headers);
 
+    // Dump headers if dump mode is enabled
+    if (this._project.dumpHeaders) {
+      ctx.log.info('=== REQUEST HEADERS ===');
+      ctx.log.info(`Request URL: ${url}`);
+      ctx.log.info(`Request Method: ${req.method}`);
+      Object.entries(headers).forEach(([key, value]) => {
+        ctx.log.info(`${key}: ${value}`);
+      });
+      ctx.log.info('=======================');
+    }
+
     const ret = await getFetch(ctx.config.allowInsecure)(url, {
       method: req.method,
       headers,
@@ -186,8 +197,8 @@ export class HelixImportServer extends BaseServer {
         host = new URL(host).origin;
         const url = this._makeProxyURL(ctx.url, host);
         await this._doProxyRequest(ctx, url, host, req, res);
-      // codecov:ignore:start
-      /* c8 ignore start */
+        // codecov:ignore:start
+        /* c8 ignore start */
       } catch (err) {
         log.error(`Failed to proxy AEM request ${ctx.path}: ${err.message}`);
         res.status(502).send(`Failed to proxy AEM request: ${err.message}`);

--- a/test/dump-headers.test.js
+++ b/test/dump-headers.test.js
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable func-names */
+import assert from 'assert';
+import path from 'path';
+import nock from 'nock';
+import { HelixImportProject } from '../src/server/HelixImportProject.js';
+import { createTestRoot, setupProject, rawGet } from './utils.js';
+
+const TEST_DIR = path.resolve(__rootdir, 'test', 'fixtures', 'import');
+
+describe('Dump Headers Functionality', () => {
+  let testRoot;
+
+  beforeEach(async () => {
+    testRoot = await createTestRoot();
+  });
+
+  afterEach(async () => {
+    nock.cleanAll();
+  });
+
+  describe('HelixImportProject', () => {
+    it('should enable dump headers when set', async () => {
+      const project = new HelixImportProject()
+        .withDumpHeaders(true);
+
+      assert.strictEqual(project.dumpHeaders, true);
+    });
+
+    it('should disable dump headers by default', async () => {
+      const project = new HelixImportProject();
+
+      assert.strictEqual(project.dumpHeaders, false);
+    });
+
+    it('should set dump headers via withDumpHeaders', async () => {
+      const project = new HelixImportProject()
+        .withDumpHeaders(true);
+
+      assert.strictEqual(project.dumpHeaders, true);
+
+      const project2 = project.withDumpHeaders(false);
+      assert.strictEqual(project2.dumpHeaders, false);
+    });
+  });
+
+  describe('Dump Headers Output', () => {
+    it('should output headers when dump-headers is enabled', async () => {
+      const cwd = await setupProject(TEST_DIR, testRoot);
+
+      // Create a mock logger that captures log messages
+      const logMessages = [];
+      const mockLogger = {
+        info: (message) => {
+          logMessages.push({ level: 'info', message });
+        },
+        debug: (message) => {
+          logMessages.push({ level: 'debug', message });
+        },
+        error: (message) => {
+          logMessages.push({ level: 'error', message });
+        },
+        warn: (message) => {
+          logMessages.push({ level: 'warn', message });
+        },
+      };
+
+      const project = new HelixImportProject()
+        .withCwd(cwd)
+        .withHttpPort(0)
+        .withDumpHeaders(true)
+        .withLogger(mockLogger);
+
+      await project.init();
+
+      try {
+        await project.start();
+
+        // Mock the external server
+        nock('http://example.com')
+          .get('/')
+          .reply(200, 'OK');
+
+        // Make a request through the proxy
+        const response = await rawGet('127.0.0.1', project.server.port, '/?host=http://example.com', {
+          'user-agent': 'test-agent',
+          accept: 'text/html',
+          'custom-header': 'custom-value',
+        });
+
+        // Verify the request was successful
+        assert.match(response.toString(), /^HTTP\/1\.1 200 OK/);
+
+        // Check that debug headers were logged
+        const headerLogs = logMessages.filter((log) => log.message.includes('=== REQUEST HEADERS ===')
+          || log.message.includes('Request URL:')
+          || log.message.includes('Request Method:')
+          || log.message.includes('user-agent:')
+          || log.message.includes('accept:')
+          || log.message.includes('custom-header:'));
+
+        assert.ok(headerLogs.length > 0, 'No header debug logs found');
+
+        // Verify the header dump structure
+        const headerDumpStart = logMessages.findIndex((log) => log.message === '=== REQUEST HEADERS ===');
+        assert.ok(headerDumpStart >= 0, 'Header dump start marker not found');
+
+        const headerDumpEnd = logMessages.findIndex((log) => log.message === '=======================');
+        assert.ok(headerDumpEnd >= 0, 'Header dump end marker not found');
+        assert.ok(headerDumpEnd > headerDumpStart, 'Header dump end before start');
+
+        // Verify that at least some headers are being logged
+        const headerEntries = logMessages.slice(headerDumpStart + 1, headerDumpEnd);
+        const hasHeaders = headerEntries.some((entry) => entry.message.includes(':'));
+        assert.ok(hasHeaders, 'No header entries found in debug output');
+
+        // Verify that the basic structure is correct
+        const hasRequestUrl = logMessages.some((log) => log.message.startsWith('Request URL:'));
+        const hasRequestMethod = logMessages.some((log) => log.message.startsWith('Request Method:'));
+
+        assert.ok(hasRequestUrl, 'Request URL not logged');
+        assert.ok(hasRequestMethod, 'Request Method not logged');
+      } finally {
+        await project.stop();
+      }
+    });
+
+    it('should not output headers when dump-headers is disabled', async () => {
+      const cwd = await setupProject(TEST_DIR, testRoot);
+
+      // Create a mock logger that captures log messages
+      const logMessages = [];
+      const mockLogger = {
+        info: (message) => {
+          logMessages.push({ level: 'info', message });
+        },
+        debug: (message) => {
+          logMessages.push({ level: 'debug', message });
+        },
+        error: (message) => {
+          logMessages.push({ level: 'error', message });
+        },
+        warn: (message) => {
+          logMessages.push({ level: 'warn', message });
+        },
+      };
+
+      const project = new HelixImportProject()
+        .withCwd(cwd)
+        .withHttpPort(0)
+        .withDumpHeaders(false)
+        .withLogger(mockLogger);
+
+      await project.init();
+
+      try {
+        await project.start();
+
+        // Mock the external server
+        nock('http://example.com')
+          .get('/')
+          .reply(200, 'OK');
+
+        // Make a request through the proxy
+        const response = await rawGet('127.0.0.1', project.server.port, '/?host=http://example.com', {
+          'user-agent': 'test-agent',
+          accept: 'text/html',
+        });
+
+        // Verify the request was successful
+        assert.match(response.toString(), /^HTTP\/1\.1 200 OK/);
+
+        // Check that debug headers were NOT logged
+        const headerLogs = logMessages.filter((log) => log.message.includes('=== REQUEST HEADERS ===')
+          || log.message.includes('Request URL:')
+          || log.message.includes('Request Method:'));
+
+        assert.strictEqual(headerLogs.length, 0, 'Header debug logs found when dump-headers is disabled');
+      } finally {
+        await project.stop();
+      }
+    });
+
+    it('should include custom headers from headers.json file in debug output', async () => {
+      const cwd = await setupProject(TEST_DIR, testRoot);
+
+      // Create a mock logger that captures log messages
+      const logMessages = [];
+      const mockLogger = {
+        info: (message) => {
+          logMessages.push({ level: 'info', message });
+        },
+        debug: (message) => {
+          logMessages.push({ level: 'debug', message });
+        },
+        error: (message) => {
+          logMessages.push({ level: 'error', message });
+        },
+        warn: (message) => {
+          logMessages.push({ level: 'warn', message });
+        },
+      };
+
+      const project = new HelixImportProject()
+        .withCwd(cwd)
+        .withHttpPort(0)
+        .withDumpHeaders(true)
+        .withHeadersFile('test/fixtures/import/headers.json')
+        .withLogger(mockLogger);
+
+      await project.init();
+
+      try {
+        await project.start();
+
+        // Mock the external server
+        nock('http://example.com')
+          .get('/')
+          .reply(200, 'OK');
+
+        // Make a request through the proxy
+        const response = await rawGet('127.0.0.1', project.server.port, '/?host=http://example.com');
+
+        // Verify the request was successful
+        assert.match(response.toString(), /^HTTP\/1\.1 200 OK/);
+
+        // Check that custom headers from headers.json were logged
+        const headerLogs = logMessages.filter((log) => log.message.includes('Cookie:')
+          || log.message.includes('Authorization_test:'));
+
+        assert.ok(headerLogs.length > 0, 'Custom headers from headers.json not logged');
+
+        // Verify specific custom headers were logged
+        const headerEntries = logMessages.filter((log) => log.message.includes('Cookie:') || log.message.includes('Authorization_test:'));
+
+        const cookieHeader = headerEntries.find((entry) => entry.message.startsWith('Cookie:'));
+        const authHeader = headerEntries.find((entry) => entry.message.startsWith('Authorization_test:'));
+
+        assert.ok(cookieHeader, 'Cookie header not found in debug output');
+        assert.ok(authHeader, 'Authorization_test header not found in debug output');
+        assert.ok(cookieHeader.message.includes('session_id=1234567890'), 'Cookie header value not correct');
+        assert.ok(authHeader.message.includes('Bearer your_token_here'), 'Authorization header value not correct');
+      } finally {
+        await project.stop();
+      }
+    });
+  });
+});

--- a/test/import-cli.test.js
+++ b/test/import-cli.test.js
@@ -45,6 +45,7 @@ describe('hlx import', () => {
     mockImport.withUIRepo.returnsThis();
     mockImport.withAllowInsecure.returnsThis();
     mockImport.withHeadersFile.returnsThis();
+    mockImport.withDumpHeaders.returnsThis();
     mockImport.run.returnsThis();
     cli = (await new CLI().initCommands()).withCommandExecutor('import', mockImport);
   });
@@ -142,6 +143,12 @@ describe('hlx import', () => {
   it('hlx import can add custom headers', async () => {
     await cli.run(['import', '--headers-file', 'headers.json']);
     sinon.assert.calledWith(mockImport.withHeadersFile, 'headers.json');
+    sinon.assert.calledOnce(mockImport.run);
+  });
+
+  it('hlx import can enable dump headers', async () => {
+    await cli.run(['import', '--dump-headers']);
+    sinon.assert.calledWith(mockImport.withDumpHeaders, true);
     sinon.assert.calledOnce(mockImport.run);
   });
 });


### PR DESCRIPTION
fixes: #2576 

Sample output:

```
info: =======================
info: === REQUEST HEADERS ===
info: Request URL: https://www.adobe.com/icon.svg
info: Request Method: GET
info: pragma: no-cache
info: cache-control: no-cache
info: sec-ch-ua-full-version-list: "Not;A=Brand";v="99.0.0.0", "Google Chrome";v="139.0.7258.139", "Chromium";v="139.0.7258.139"
info: sec-ch-ua-platform: "macOS"
info: sec-ch-ua: "Not;A=Brand";v="99", "Google Chrome";v="139", "Chromium";v="139"
info: sec-ch-ua-bitness: "64"
info: sec-ch-ua-model: ""
info: sec-ch-ua-mobile: ?0
info: sec-ch-ua-arch: "arm"
info: sec-ch-ua-full-version: "139.0.7258.139"
info: user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36
info: dnt: 1
info: sec-ch-ua-platform-version: "15.6.0"
info: accept: image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
info: sec-fetch-site: same-origin
info: sec-fetch-mode: no-cors
info: sec-fetch-dest: image
info: accept-language: en,fr;q=0.9,de-DE;q=0.8,de;q=0.7,ja;q=0.6,cy;q=0.5
info: x-user-agent: AU-AEM-Importer
info: =======================
```