### PR TITLE
fix(up): proxy all cookie and set-cookie headers

### DIFF
--- a/src/server/HelixProject.js
+++ b/src/server/HelixProject.js
@@ -68,6 +68,11 @@ export class HelixProject extends BaseProject {
     return this;
   }
 
+  withCookies(value) {
+    this._server.withCookies(value);
+    return this;
+  }
+
   get proxyUrl() {
     return this._proxyUrl;
   }

--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -34,6 +34,7 @@ export class HelixServer extends BaseServer {
     this._enableLiveReload = false;
     this._app.use(compression());
     this._autoLogin = true;
+    this._cookies = false;
   }
 
   withLiveReload(value) {
@@ -43,6 +44,11 @@ export class HelixServer extends BaseServer {
 
   withSiteToken(value) {
     this._siteToken = value;
+    return this;
+  }
+
+  withCookies(value) {
+    this._cookies = value;
     return this;
   }
 
@@ -205,6 +211,7 @@ export class HelixServer extends BaseServer {
         siteToken: this._siteToken,
         loginPath: LOGIN_ROUTE,
         autoLogin: this._autoLogin,
+        cookies: this._cookies,
       });
     } catch (err) {
       log.error(`${pfx}failed to proxy AEM request ${ctx.path}: ${err.message}`);

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -44,6 +44,11 @@ export default class UpCommand extends AbstractServerCommand {
     return this;
   }
 
+  withCookies(value) {
+    this._cookies = value;
+    return this;
+  }
+
   async doStop() {
     await super.doStop();
     if (this._watcher) {
@@ -76,7 +81,8 @@ export default class UpCommand extends AbstractServerCommand {
       .withKill(this._kill)
       .withPrintIndex(this._printIndex)
       .withAllowInsecure(this._allowInsecure)
-      .withSiteToken(this._siteToken);
+      .withSiteToken(this._siteToken)
+      .withCookies(this._cookies);
 
     this.log.info(chalk`{yellow     ___    ________  ___                          __      __ v${pkgJson.version}}`);
     this.log.info(chalk`{yellow    /   |  / ____/  |/  /  _____(_)___ ___  __  __/ /___ _/ /_____  _____}`);

--- a/src/up.js
+++ b/src/up.js
@@ -104,6 +104,11 @@ export default function up() {
           type: 'boolean',
           default: false,
         })
+        .option('cookies', {
+          describe: 'Proxy all cookies in requests. By default, only the hlx-auth-token cookie is proxied.',
+          type: 'boolean',
+          default: false,
+        })
 
         .help();
     },
@@ -128,6 +133,7 @@ export default function up() {
         .withAllowInsecure(argv.allowInsecure)
         .withKill(argv.stopOther)
         .withCache(argv.alphaCache)
+        .withCookies(argv.cookies)
         .run();
     },
   };

--- a/test/up-cli.test.js
+++ b/test/up-cli.test.js
@@ -49,6 +49,7 @@ describe('hlx up', () => {
     mockUp.withAllowInsecure.returnsThis();
     mockUp.withKill.returnsThis();
     mockUp.withCache.returnsThis();
+    mockUp.withCookies.returnsThis();
     mockUp.withSiteToken.returnsThis();
     mockUp.run.returnsThis();
     cli = (await new CLI().initCommands()).withCommandExecutor('up', mockUp);


### PR DESCRIPTION
## Use case

Support passing all cookies while proxying, in both directions, e.g. for custom authentication.

_**Update after I created the PR:** Originally I was trying to run `aem up` aka `localhost:3000` as proxy before a custom cloudflare worker where we do authentication using cookies. To make that authentication work, `aem up` needs to proxy cookies in both directions, which is what this PR enabled._

_But in the meantime I figured it's better to simulate the real setup where the cloudflare worker runs in front of Helix. Hence I am running the cloudflare worker (`wrangler dev`) locally now _in front_ of EDS, using `localhost:3000` as origin for Helix requests, so it can talk to `aem up` running locally as well. See https://github.com/aemsites/koassets/pull/32. For that I don't need this PR._


## Changes
1. New `--cookies` option to proxy all cookies in the requests
   - In the current implementation, only the `hlx-auth-token` cookie on requests is proxied through. I could not find a reason why but I assume there is one.
   - That's why I kept the default behavior and introduced this new option.
   - **QUESTION: If there is no need for the old behavior**, and cookies can always be passed in requests, the change would be a lot simpler and the new `--cookies` option would not be required.
2. Support multiple `Set-Cookie` headers in responses
    - These were previously incorrectly joined into a single `Set-Cookie` header, which browsers see as a single cookie, leading to incorrect results.
    - I don't think that was intentional. It's a technical limitation of the fetch Response API, which requires a special handling in node-fetch: https://www.npmjs.com/package/node-fetch#extract-set-cookie-header

Also added unit tests.

## New option

```
> aem up --help
...

Options:
...

  --cookies                          Proxy all cookies in requests. By default,
                                     only the hlx-auth-token cookie is proxied.
                                                      [boolean] [default: false]
```
