### PR TITLE
Add validation for git worktree and update submodule test command

### DIFF
--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -68,6 +68,10 @@ export default class UpCommand extends AbstractServerCommand {
         if (await GitUtils.isGitSubmodule(this.directory)) {
           throw Error('git submodules are not supported.');
         }
+        // Verify it's actually a worktree
+        if (!await GitUtils.isGitWorktree(this.directory)) {
+          throw Error('Unsupported git configuration: .git is a file but not a valid worktree or submodule.');
+        }
         // It's a worktree - this is allowed
       }
     } catch (e) {

--- a/test/git-utils.test.js
+++ b/test/git-utils.test.js
@@ -265,7 +265,8 @@ describe('Testing GitUtils', () => {
 
         // Add submodule to main repo
         shell.cd(testRoot);
-        shell.exec(`git submodule add "${submoduleRepoDir}" test-submodule`);
+        // Use -c flag to allow file protocol just for this command
+        shell.exec(`git -c protocol.file.allow=always submodule add "file://${submoduleRepoDir}" test-submodule`);
 
         const submoduleDir = path.join(testRoot, 'test-submodule');
 


### PR DESCRIPTION
## Summary
- Adds validation to ensure `.git` is a valid git worktree when `.git` is a file
- Throws error if `.git` is neither a valid worktree nor a submodule
- Updates git submodule test to use `-c protocol.file.allow=always` flag for file protocol compatibility

## Changes

### Core Functionality
- **UpCommand**: Added check in `src/up.cmd.js` to verify if `.git` is a valid git worktree using `GitUtils.isGitWorktree`
- Throws descriptive error if `.git` is a file but not a valid worktree or submodule

### Tests
- **git-utils.test.js**: Modified submodule add command to include `-c protocol.file.allow=always` flag to allow file protocol during tests

## Test plan
- [x] Verify error is thrown when `.git` is a file but not a valid worktree or submodule
- [x] Confirm submodule tests pass with updated command
- [x] Run existing tests to ensure no regressions in git utility functions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a76a0494-6a54-448b-8a06-3f4d5444de43