### PR TITLE
fix(deps): update external dependencies except isomorphic-git

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,10 @@
         "compression": "1.8.1",
         "cookie": "1.0.2",
         "cookie-parser": "1.4.7",
-        "dotenv": "17.2.1",
+        "dotenv": "17.2.2",
         "express": "5.1.0",
         "faye-websocket": "0.11.4",
-        "fs-extra": "11.3.0",
+        "fs-extra": "11.3.1",
         "glob": "11.0.3",
         "glob-to-regexp": "0.4.1",
         "hast-util-select": "6.0.4",
@@ -32,7 +32,7 @@
         "ignore": "7.0.5",
         "ini": "5.0.0",
         "isomorphic-git": "1.32.2",
-        "jose": "6.0.12",
+        "jose": "6.1.0",
         "livereload-js": "4.0.2",
         "node-fetch": "3.3.2",
         "open": "10.2.0",
@@ -52,16 +52,16 @@
       },
       "devDependencies": {
         "@adobe/eslint-config-helix": "3.0.10",
-        "@eslint/config-helpers": "0.3.0",
+        "@eslint/config-helpers": "0.3.1",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "c8": "10.1.3",
         "eslint": "9.4.0",
-        "esmock": "2.7.1",
+        "esmock": "2.7.2",
         "husky": "9.1.7",
         "junit-report-builder": "5.1.1",
-        "lint-staged": "16.1.2",
-        "mocha": "11.7.1",
+        "lint-staged": "16.1.6",
+        "mocha": "11.7.2",
         "mocha-multi-reporters": "1.5.1",
         "nock": "13.5.6",
         "semantic-release": "24.2.7",
@@ -88,16 +88,6 @@
       },
       "peerDependencies": {
         "eslint": "^9.0.0"
-      }
-    },
-    "node_modules/@adobe/eslint-config-helix/node_modules/@eslint/config-helpers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@adobe/fetch": {
@@ -140,20 +130,6 @@
         "ignore": "7.0.5",
         "lru-cache": "11.2.1",
         "yaml": "2.8.1"
-      }
-    },
-    "node_modules/@adobe/helix-shared-config/node_modules/fs-extra": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
-      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@adobe/helix-shared-config/node_modules/lru-cache": {
@@ -310,9 +286,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
-      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2548,42 +2524,34 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.0.tgz",
+      "integrity": "sha512-7JDGG+4Zp0CsknDCedl0DYdaeOhc46QNpXi3NLQblkZpXXgA6LncLDUUyvrjSvZeF3VRQa+KiMGomazQrC1V8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^7.0.0"
+        "slice-ansi": "^7.1.0",
+        "string-width": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-truncate/node_modules/emoji-regex": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
-      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
+        "get-east-asian-width": "^1.3.0",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3383,9 +3351,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4144,9 +4112,9 @@
       "license": "MIT"
     },
     "node_modules/esmock": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/esmock/-/esmock-2.7.1.tgz",
-      "integrity": "sha512-YgtZ6TSwRbdqFLkJwxVCYkt0rzKpjHb0tbDqSjWvbkm8Uy5Tm5W6ixICb3FVRkAd1uQlLOXiIn7OPY4F4f18cw==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/esmock/-/esmock-2.7.2.tgz",
+      "integrity": "sha512-/ilhkWbW4FXgQpRbS0LZpKG1AFkiFZkmapP/868Lqa4hSKgKVtMilFXlQrIMssLzyvpeDVg2Q9L3VInnqYoTAg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4793,9 +4761,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5988,13 +5956,16 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6463,9 +6434,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.12.tgz",
-      "integrity": "sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
+      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -6652,22 +6623,22 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "16.1.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.2.tgz",
-      "integrity": "sha512-sQKw2Si2g9KUZNY3XNvRuDq4UJqpHwF0/FQzZR2M7I5MvtpWvibikCjUVJzZdGE0ByurEl3KQNvsGetd1ty1/Q==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.6.tgz",
+      "integrity": "sha512-U4kuulU3CKIytlkLlaHcGgKscNfJPNTiDF2avIUGFCv7K95/DCYQ7Ra62ydeRWmgQGg9zJYw2dzdbztwJlqrow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.4.1",
+        "chalk": "^5.6.0",
         "commander": "^14.0.0",
         "debug": "^4.4.1",
         "lilconfig": "^3.1.3",
-        "listr2": "^8.3.3",
+        "listr2": "^9.0.3",
         "micromatch": "^4.0.8",
         "nano-spawn": "^1.0.2",
         "pidtree": "^0.6.0",
         "string-argv": "^0.3.2",
-        "yaml": "^2.8.0"
+        "yaml": "^2.8.1"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -6680,13 +6651,13 @@
       }
     },
     "node_modules/listr2": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
-      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.4.tgz",
+      "integrity": "sha512-1wd/kpAdKRLwv7/3OKC8zZ5U8e/fajCfWMxacUvB79S5nLrYGPtUI/8chMQhn3LQjsRVErTb9i1ECAwW0ZIHnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^4.0.0",
+        "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
         "eventemitter3": "^5.0.1",
         "log-update": "^6.1.0",
@@ -6694,7 +6665,7 @@
         "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/listr2/node_modules/emoji-regex": {
@@ -6950,39 +6921,6 @@
       "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
     },
     "node_modules/log-update/node_modules/string-width": {
       "version": "7.2.0",
@@ -7708,9 +7646,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
-      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.2.tgz",
+      "integrity": "sha512-lkqVJPmqqG/w5jmmFtiRvtA2jkDyNVUcefFJKb2uyX4dekk8Okgqop3cgbFiaIvj8uCRJVTP5x9dfxGyXm2jvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13208,17 +13146,17 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.0.0",
-        "is-fullwidth-code-point": "^4.0.0"
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "reporter-options": "configFile=.mocha-multi.json",
     "loader": "esmock",
     "exclude": [
-      "test/browser/**"
+      "test/browser/**",
+      "test/tmp/**"
     ]
   },
   "repository": {
@@ -53,10 +54,10 @@
     "compression": "1.8.1",
     "cookie": "1.0.2",
     "cookie-parser": "1.4.7",
-    "dotenv": "17.2.1",
+    "dotenv": "17.2.2",
     "express": "5.1.0",
     "faye-websocket": "0.11.4",
-    "fs-extra": "11.3.0",
+    "fs-extra": "11.3.1",
     "glob": "11.0.3",
     "glob-to-regexp": "0.4.1",
     "hast-util-select": "6.0.4",
@@ -65,7 +66,7 @@
     "ignore": "7.0.5",
     "ini": "5.0.0",
     "isomorphic-git": "1.32.2",
-    "jose": "6.0.12",
+    "jose": "6.1.0",
     "livereload-js": "4.0.2",
     "node-fetch": "3.3.2",
     "open": "10.2.0",
@@ -81,16 +82,16 @@
   },
   "devDependencies": {
     "@adobe/eslint-config-helix": "3.0.10",
-    "@eslint/config-helpers": "0.3.0",
+    "@eslint/config-helpers": "0.3.1",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "c8": "10.1.3",
     "eslint": "9.4.0",
-    "esmock": "2.7.1",
+    "esmock": "2.7.2",
     "husky": "9.1.7",
     "junit-report-builder": "5.1.1",
-    "lint-staged": "16.1.2",
-    "mocha": "11.7.1",
+    "lint-staged": "16.1.6",
+    "mocha": "11.7.2",
     "mocha-multi-reporters": "1.5.1",
     "nock": "13.5.6",
     "semantic-release": "24.2.7",


### PR DESCRIPTION
## Summary
- Updates several external dependencies to their latest patch/minor versions  
- Excludes `test/tmp/**` from mocha tests to prevent browser code from being loaded in Node.js environment
- Intentionally holds `isomorphic-git` at version 1.32.2 (will be updated separately)

## Dependencies Updated
- `@eslint/config-helpers`: 0.3.0 → 0.3.1
- `dotenv`: 17.2.1 → 17.2.2
- `esmock`: 2.7.1 → 2.7.2
- `fs-extra`: 11.3.0 → 11.3.1
- `jose`: 6.0.12 → 6.1.0
- `lint-staged`: 16.1.2 → 16.1.6
- `mocha`: 11.7.1 → 11.7.2

## Test plan
- [x] All tests pass locally (209 passing)
- [ ] CI passes on PR

## Context
This PR is created to isolate dependency updates from the isomorphic-git update which requires code changes. See #2593 for the original renovate PR that was failing.

🤖 Generated with [Claude Code](https://claude.ai/code)