### PR TITLE
fix: filter out invalid DNS names in getBranch tags

### DIFF
--- a/src/git-utils.js
+++ b/src/git-utils.js
@@ -136,6 +136,18 @@ export default class GitUtils {
   }
 
   /**
+   * Checks if a name is valid for use in a DNS subdomain.
+   * DNS labels must not contain dots or other special characters.
+   * @param {string} name the name to validate
+   * @returns {boolean} true if valid for DNS
+   */
+  static isValidDNSName(name) {
+    // DNS labels can only contain alphanumeric characters and hyphens
+    // They cannot contain dots or other special characters
+    return /^[a-zA-Z0-9-]+$/.test(name);
+  }
+
+  /**
    * Returns the name of the current branch. If `HEAD` is at a tag, the name of the tag
    * will be returned instead, if head is at a commit, fallback will be returned.
    *
@@ -178,7 +190,11 @@ export default class GitUtils {
         ? await git.resolveRef({ fs, dir, ref: obj.object.object }) // annotated tag
         : oid; // lightweight tag
       if (commitSha === rev) {
-        return tag;
+        // Only return tags that are valid for DNS names
+        // Skip tags containing dots or other invalid characters
+        if (GitUtils.isValidDNSName(tag)) {
+          return tag;
+        }
       }
     }
 

--- a/src/git-utils.js
+++ b/src/git-utils.js
@@ -137,14 +137,24 @@ export default class GitUtils {
 
   /**
    * Checks if a name is valid for use in a DNS subdomain.
-   * DNS labels must not contain dots or other special characters.
+   * DNS labels must:
+   * - Be between 1 and 63 characters long
+   * - Contain only alphanumeric characters and hyphens
+   * - Not start or end with a hyphen
+   * - Not contain dots or other special characters
    * @param {string} name the name to validate
    * @returns {boolean} true if valid for DNS
    */
   static isValidDNSName(name) {
+    // Check length (DNS labels must be 1-63 characters)
+    if (!name || name.length > 63) {
+      return false;
+    }
+
     // DNS labels can only contain alphanumeric characters and hyphens
+    // They cannot start or end with hyphens
     // They cannot contain dots or other special characters
-    return /^[a-zA-Z0-9-]+$/.test(name);
+    return /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(name);
   }
 
   /**

--- a/test/git-utils.test.js
+++ b/test/git-utils.test.js
@@ -284,11 +284,13 @@ describe('Testing GitUtils', () => {
     });
 
     it('isValidDNSName validates DNS-compatible names', () => {
-      // Valid DNS names (alphanumeric and hyphens only)
+      // Valid DNS names (alphanumeric and hyphens, proper format)
       assert.equal(GitUtils.isValidDNSName('main'), true);
       assert.equal(GitUtils.isValidDNSName('feature-branch'), true);
       assert.equal(GitUtils.isValidDNSName('v1-0-0'), true);
       assert.equal(GitUtils.isValidDNSName('release-2024'), true);
+      assert.equal(GitUtils.isValidDNSName('a'), true); // single character is valid
+      assert.equal(GitUtils.isValidDNSName('1'), true); // single digit is valid
 
       // Invalid DNS names (containing dots or other special chars)
       assert.equal(GitUtils.isValidDNSName('v1.0.0'), false);
@@ -296,6 +298,20 @@ describe('Testing GitUtils', () => {
       assert.equal(GitUtils.isValidDNSName('branch_name'), false);
       assert.equal(GitUtils.isValidDNSName('branch@name'), false);
       assert.equal(GitUtils.isValidDNSName('1.2.3'), false);
+
+      // Invalid DNS names (hyphens at start or end)
+      assert.equal(GitUtils.isValidDNSName('-branch'), false);
+      assert.equal(GitUtils.isValidDNSName('branch-'), false);
+      assert.equal(GitUtils.isValidDNSName('-'), false);
+
+      // Invalid DNS names (length issues)
+      assert.equal(GitUtils.isValidDNSName(''), false); // empty string
+      assert.equal(GitUtils.isValidDNSName(null), false); // null
+      assert.equal(GitUtils.isValidDNSName(undefined), false); // undefined
+      // 64 characters (too long)
+      assert.equal(GitUtils.isValidDNSName('a'.repeat(64)), false);
+      // 63 characters (max valid length)
+      assert.equal(GitUtils.isValidDNSName('a'.repeat(63)), true);
     });
 
     it('hashBranchToPort generates consistent ports', () => {


### PR DESCRIPTION
## Summary
- Adds validation to ensure only DNS-compatible names are returned by `getBranch` when resolving tags
- Introduces `isValidDNSName` method to check if a name is valid for DNS subdomains
- Filters out tags containing dots or special characters that are invalid in DNS names

## Changes

### Core Functionality
- **GitUtils.isValidDNSName**: New static method to validate DNS-compatible names (alphanumeric and hyphens only)
- **getBranch**: Updated to return tags only if they pass the DNS name validation

### Tests
- Added unit tests for `isValidDNSName` covering valid and invalid DNS names
- Updated `getBranch` tests to verify tags with dots are ignored and tags without dots are returned

## Test plan
- [x] Verify `isValidDNSName` correctly validates various branch/tag names
- [x] Confirm `getBranch` returns valid DNS-compatible tags and skips invalid ones
- [x] Run existing tests to ensure no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/98bc2ca4-2f58-433f-9401-de0a7462a903