### PR TITLE
fix: enable npm trusted publishers with OIDC

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,6 +9,7 @@ permissions:
   contents: write  # semantic-release-dry verifies the write permissions
   issues: read # needed by semantic-release
   pull-requests: write # needed by semantic-release
+  id-token: write # needed for npm trusted publishers with OIDC
 
 jobs:
   test:
@@ -16,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v5
         with:
           node-version: '22.x'
@@ -63,7 +64,7 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v5
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v5
         with:
           node-version: '22.x'
@@ -85,10 +86,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Use Node.js 20.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v5
         with:
-          node-version: '22.x'
+          node-version: '24.x'
       - run: npm ci
       - run: npm run semantic-release
         env:


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission required for OIDC authentication
- Updates Node.js to 24.x in release job only (required for npm CLI v11.5.1+)
- Enables publishing without NPM_TOKEN using npm trusted publishers

## Context
The release workflow was failing because npm trusted publishers require:
1. `id-token: write` permission for GitHub Actions to generate OIDC tokens
2. npm CLI v11.5.1+ which is only available with Node.js 24+

This fix enables the workflow to authenticate with npm using OIDC instead of traditional npm tokens, as configured in the trusted publishers settings.

## Test plan
- [x] Release job now uses Node.js 24.x
- [x] Test jobs continue to use Node.js 22.x (no unnecessary changes)
- [x] Workflow has required `id-token: write` permission
- [ ] Verify release workflow succeeds after merge

Fixes https://github.com/adobe/helix-cli/actions/runs/18563806737/job/52919886258

🤖 Generated with [Claude Code](https://claude.com/claude-code)