### PR TITLE
fix: enable npm trusted publishers with OIDC

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,8 +91,9 @@ jobs:
         with:
           node-version: '24.x'
       - run: npm ci
+      - name: Check npm version
+        run: npm --version
       - run: npm run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
           DISCORD_WEBHOOK: ${{ secrets.HELIX_RELEASE_DISCORD_WEBHOOK }}


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission required for OIDC authentication
- Updates Node.js to 24.x in release job only (required for npm CLI v11.5.1+)
- **Removes `NPM_TOKEN` from workflow** - this is critical for OIDC to work
- Adds npm version logging for debugging

## Context
The release workflow was failing with:
```
npm error 403 Two-factor authentication is required to publish this package but an automation token was specified
```

This happens when npm trusted publishers are configured but `NPM_TOKEN` is still passed to the workflow. When `NPM_TOKEN` is present, npm uses the automation token instead of OIDC authentication.

### What npm trusted publishers require:
1. `id-token: write` permission for GitHub Actions to generate OIDC tokens
2. npm CLI v11.5.1+ (only available with Node.js 24+)
3. **No `NPM_TOKEN` in environment** - OIDC authentication happens automatically via the id-token permission

## Changes
- Added `id-token: write` permission to workflow
- Updated Node.js to 24.x in release job (test jobs remain at 22.x)
- **Removed `NPM_TOKEN` environment variable** from semantic-release step
- Added npm version logging step for debugging

## Test plan
- [x] Release job uses Node.js 24.x with npm v11.5.1+
- [x] Test jobs continue to use Node.js 22.x
- [x] Workflow has required `id-token: write` permission
- [x] NPM_TOKEN removed from semantic-release environment
- [ ] Verify release workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)