### PR TITLE
chore: update to Node.js 24.x and actions/setup-node@v6

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '22.x'
       - run: npm ci
@@ -65,7 +65,7 @@ jobs:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v5
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '22.x'
       - run: npm ci
@@ -87,7 +87,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24.x'
       - run: npm ci


### PR DESCRIPTION
## Summary
Updates only the actions/setup-node action from v5 to v6, keeping Node.js versions stable. This isolates the setup-node update from Node.js version changes to identify any issues.

## Changes
- ✅ Update actions/setup-node from v5 to v6 in all jobs
- ✅ Keep Node.js versions unchanged:
  - Test jobs: Node.js 22.x
  - Release job: Node.js 24.x

## Test plan
- ✅ CI should pass all tests with setup-node v6
- ✅ No functional changes to Node.js versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)