### PR TITLE
chore: update to Node.js 24.x with OIDC-compatible semantic-release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v5
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24.x'
       - run: npm ci
 
       # Sub-project setup and testing (conditional)
@@ -53,8 +53,7 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         run: npm run semantic-release-dry
         env:
-          GITHUB_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK: ${{ secrets.HELIX_RELEASE_DISCORD_WEBHOOK }}
 
   test_win:
@@ -64,10 +63,10 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v5
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v5
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24.x'
       - run: npm ci
       - run: git config --global user.email "test@project-helix.io" && git config --global user.name "Test Build"
       - run: git config --global protocol.file.allow always
@@ -86,10 +85,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Use Node.js 24.x
-        uses: actions/setup-node@v5
+      - name: Use Node.js 24.11 (LTS)
+        uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          node-version: '24.11.0'
       - run: npm ci
       - name: Check npm version
         run: npm --version

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "mocha": "11.7.4",
         "mocha-multi-reporters": "1.5.1",
         "nock": "13.5.6",
-        "semantic-release": "25.0.0",
+        "semantic-release": "25.0.1",
         "semantic-release-discord-bot": "^1.1.0",
         "sinon": "21.0.0"
       },
@@ -621,6 +621,7 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -1445,6 +1446,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1572,7 +1574,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -1843,7 +1844,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -3819,6 +3819,7 @@
       "integrity": "sha512-sjc7Y8cUD1IlwYcTS9qPSvGjAC8Ne9LctpxKKu3x/1IC9bnOg98Zy6GxEJUfr1NojMgVPlyANXYns8oE2c1TAA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4740,7 +4741,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -5760,7 +5760,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -6993,6 +6992,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8046,7 +8046,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10453,6 +10452,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12090,16 +12090,17 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.0.tgz",
-      "integrity": "sha512-JL2hY7b1hBli5FS98nAXH0OwfRsgdywuUVhKktyJOHu9tUO0wJGWNpQL69SDhJ5Uwp63rtIvGvy7ZDy4C3RsXg==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.1.tgz",
+      "integrity": "sha512-0OCYLm0AfVilNGukM+w0C4aptITfuW1Mhvmz8LQliLeYbPOTFRCIJzoltWWx/F5zVFe6np9eNatBUHdAvMFeZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
         "@semantic-release/github": "^12.0.0",
-        "@semantic-release/npm": "^13.0.0",
+        "@semantic-release/npm": "^13.1.1",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "aggregate-error": "^5.0.0",
         "cosmiconfig": "^9.0.0",
@@ -12158,33 +12159,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/semantic-release-discord-bot/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/semantic-release-discord-bot/node_modules/commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -12202,7 +12176,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -12243,7 +12216,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -13846,6 +13818,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "mocha": "11.7.4",
     "mocha-multi-reporters": "1.5.1",
     "nock": "13.5.6",
-    "semantic-release": "25.0.0",
+    "semantic-release": "25.0.1",
     "semantic-release-discord-bot": "^1.1.0",
     "sinon": "21.0.0"
   },


### PR DESCRIPTION
## Summary
Updates to Node.js 24.x, setup-node v6, and semantic-release 25.0.1 with a fix for semantic-release dry-run failures on bot-created PRs.

## Changes
- ✅ Update test jobs from Node.js 22.x to 24.x
- ✅ Update actions/setup-node from v5 to v6
- ✅ Pin release job to Node.js 24.11.0 LTS
- ✅ Update semantic-release from 25.0.0 to 25.0.1
- ✅ **Fix**: Use built-in `secrets.GITHUB_TOKEN` for dry-run instead of `ADOBE_BOT_GITHUB_TOKEN`
- ✅ Remove `NPM_TOKEN` from dry-run (not needed with OIDC)

## Problem Solved
Previous PRs failed because `secrets.ADOBE_BOT_GITHUB_TOKEN` is not accessible to workflows triggered by bot PRs (Renovate, Dependabot). This is a GitHub security feature to prevent credential theft.

## Solution
The semantic-release dry-run now uses the built-in `secrets.GITHUB_TOKEN` which is always available, even for bot-created PRs. The actual release step on main still uses `ADOBE_BOT_GITHUB_TOKEN` with full permissions.

## OIDC Support
The workflow already has `id-token: write` permission configured, enabling npm OIDC trusted publishing. The `NPM_TOKEN` has been removed from the dry-run step as it's not needed for verification.

## Test plan
- ✅ All tests should pass with Node.js 24.x
- ✅ Semantic-release dry-run should complete successfully (KEY TEST!)
- ✅ Works for bot-created PRs (unlike PRs #2624 and #2627)

## Related PRs
- #2624 - Renovate's original PR (has isomorphic-git fix)
- #2626 - Tests only setup-node v6 upgrade
- #2627 - Combined update without OIDC fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)