### PR TITLE
fix(html-folder): support index files for directory requests with trailing slash

### DIFF
--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -259,7 +259,12 @@ export class HelixServer extends BaseServer {
     }
 
     // Extract the path within the HTML folder
-    const relativePath = pathname.slice(folderPrefix.length);
+    let relativePath = pathname.slice(folderPrefix.length);
+
+    // Handle directory requests (trailing slash) by appending 'index'
+    if (relativePath === '' || relativePath.endsWith('/')) {
+      relativePath = `${relativePath}index`.replace(/\/+/g, '/');
+    }
 
     // Resolve which file to serve (.html or .plain.html)
     const resolvedFile = await this.resolveHtmlFolderFile(relativePath);


### PR DESCRIPTION
## Summary

  Fixes directory requests in HTML folder mode to properly serve `index.html` and `index.plain.html` files.

  ## Changes

  When a request comes in with a trailing slash (e.g., `/drafts/` or `/drafts/section/`), the handler now appends `index` to the path before checking for `.html` or `.plain.html` files.

These now work:
 /drafts/ → serves drafts/index.html or drafts/index.plain.html
 /drafts/section/ → serves drafts/section/index.html or drafts/section/index.plain.html

 ## Testing

  Added 3 tests covering index file scenarios.