### PR TITLE
fix: Add --preferPlainHtml flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Plain HTML files contain only the main content and an optional metadata block. T
 - Merges in `head.html` content
 - The metadata block is removed from the rendered content and converted to meta tags in the `<head>`.
 
+When a request resolves to `<stem>`, the CLI looks up `<stem>.html` first and falls back to `<stem>.plain.html`. Pass `--preferPlainHtml` to reverse this order — useful when you keep both files side-by-side and want the plain version to win:
+
+```
+$ aem up --html-folder drafts --preferPlainHtml
+```
+
 ### setting up a self-signed cert for using https
 
 1. create the certificate
@@ -188,6 +194,7 @@ If present, `ALL_PROXY` is used as fallback if there is no other match.
 | `--forward-browser-logs` | `AEM_FORWARD_BROWSER_LOGS` | `false` | Forward browser console logs to terminal.            |
 | `--html-folder`   | `AEM_HTML_FOLDER`   | undefined   | Serve HTML files from folder without extensions. |
 | `--html-mount`    | `AEM_HTML_MOUNT`    | `/FOLDER`   | URL path where html-folder files are served. |
+| `--prefer-plain-html` | `AEM_PREFER_PLAIN_HTML` | `false` | Prefer `<stem>.plain.html` over `<stem>.html` when both exist. |
 | `--open`          | `AEM_OPEN`          | `/`         | Open a browser window at specified path after server start. |
 | `--no-open`       | `AEM_NO_OPEN`       | `false`     | Disable automatic opening of browser window.                |
 | `--tls-key`       | `AEM_TLS_KEY`       | undefined   | Path to .key file (for enabling TLS)                        |

--- a/src/server/HelixProject.js
+++ b/src/server/HelixProject.js
@@ -99,6 +99,11 @@ export class HelixProject extends BaseProject {
     return this;
   }
 
+  withPreferPlainHtml(value) {
+    this._preferPlainHtml = value;
+    return this;
+  }
+
   get proxyUrl() {
     return this._proxyUrl;
   }
@@ -152,6 +157,7 @@ export class HelixProject extends BaseProject {
     if (this._htmlFolder) {
       const mount = this._htmlMount || `/${this._htmlFolder}`;
       this._server.withHtmlFolder(this._htmlFolder, mount);
+      this._server.withPreferPlainHtml(this._preferPlainHtml);
     }
     await super.init();
     this._indexer = new Indexer()

--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -205,6 +205,35 @@ export class HelixServer extends BaseServer {
   }
 
   /**
+   * Resolves a candidate file inside the HTML folder, returning its absolute path
+   * if it exists and passes the security check, or null otherwise.
+   * @param {string} relativePath path relative to HTML folder (without extension)
+   * @param {string} ext extension to append (e.g. '.html', '.plain.html')
+   * @returns {Promise<string|null>} absolute path, or null if missing/invalid
+   */
+  async resolveCandidate(relativePath, ext) {
+    const file = path.resolve(
+      this._project.directory,
+      this._htmlFolder,
+      `${relativePath}${ext}`,
+    );
+
+    if (!utils.validatePathSecurity(file, this._project.directory)) {
+      return null;
+    }
+
+    try {
+      const stats = await lstat(file);
+      if (stats.isFile()) {
+        return file;
+      }
+    } catch (e) {
+      // not found
+    }
+    return null;
+  }
+
+  /**
    * Resolves which HTML file to serve from the HTML folder
    * @param {string} relativePath path relative to HTML folder
    * @returns {Promise<{file: string, isPlain: boolean}|null>} resolved file info or null
@@ -220,48 +249,16 @@ export class HelixServer extends BaseServer {
       return null;
     }
 
-    const [firstExt, secondExt] = this._preferPlainHtml
+    const candidates = this._preferPlainHtml
       ? ['.plain.html', '.html']
       : ['.html', '.plain.html'];
 
-    // Try first extension
-    const firstFile = path.resolve(
-      this._project.directory,
-      this._htmlFolder,
-      `${relativePath}${firstExt}`,
-    );
-
-    if (!utils.validatePathSecurity(firstFile, this._project.directory)) {
-      return null;
-    }
-
-    try {
-      const stats = await lstat(firstFile);
-      if (stats.isFile()) {
-        return { file: firstFile, isPlain: firstExt === '.plain.html' };
+    for (const ext of candidates) {
+      // eslint-disable-next-line no-await-in-loop
+      const file = await this.resolveCandidate(relativePath, ext);
+      if (file) {
+        return { file, isPlain: ext === '.plain.html' };
       }
-    } catch (e) {
-      // first extension not found, try second
-    }
-
-    // Try second extension
-    const secondFile = path.resolve(
-      this._project.directory,
-      this._htmlFolder,
-      `${relativePath}${secondExt}`,
-    );
-
-    if (!utils.validatePathSecurity(secondFile, this._project.directory)) {
-      return null;
-    }
-
-    try {
-      const stats = await lstat(secondFile);
-      if (stats.isFile()) {
-        return { file: secondFile, isPlain: secondExt === '.plain.html' };
-      }
-    } catch (e) {
-      // Neither exists
     }
 
     return null;

--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -92,6 +92,11 @@ export class HelixServer extends BaseServer {
     return this;
   }
 
+  withPreferPlainHtml(value) {
+    this._preferPlainHtml = value;
+    return this;
+  }
+
   get mountPrefix() {
     return this._mountPrefix;
   }
@@ -215,41 +220,45 @@ export class HelixServer extends BaseServer {
       return null;
     }
 
-    // Try .html first
-    const htmlFile = path.resolve(
+    const [firstExt, secondExt] = this._preferPlainHtml
+      ? ['.plain.html', '.html']
+      : ['.html', '.plain.html'];
+
+    // Try first extension
+    const firstFile = path.resolve(
       this._project.directory,
       this._htmlFolder,
-      `${relativePath}.html`,
+      `${relativePath}${firstExt}`,
     );
 
-    if (!utils.validatePathSecurity(htmlFile, this._project.directory)) {
+    if (!utils.validatePathSecurity(firstFile, this._project.directory)) {
       return null;
     }
 
     try {
-      const stats = await lstat(htmlFile);
+      const stats = await lstat(firstFile);
       if (stats.isFile()) {
-        return { file: htmlFile, isPlain: false };
+        return { file: firstFile, isPlain: firstExt === '.plain.html' };
       }
     } catch (e) {
-      // .html not found, try .plain.html
+      // first extension not found, try second
     }
 
-    // Try .plain.html
-    const plainHtmlFile = path.resolve(
+    // Try second extension
+    const secondFile = path.resolve(
       this._project.directory,
       this._htmlFolder,
-      `${relativePath}.plain.html`,
+      `${relativePath}${secondExt}`,
     );
 
-    if (!utils.validatePathSecurity(plainHtmlFile, this._project.directory)) {
+    if (!utils.validatePathSecurity(secondFile, this._project.directory)) {
       return null;
     }
 
     try {
-      const stats = await lstat(plainHtmlFile);
+      const stats = await lstat(secondFile);
       if (stats.isFile()) {
-        return { file: plainHtmlFile, isPlain: true };
+        return { file: secondFile, isPlain: secondExt === '.plain.html' };
       }
     } catch (e) {
       // Neither exists

--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -212,15 +212,14 @@ export class HelixServer extends BaseServer {
   /**
    * Resolves a candidate file inside the HTML folder, returning its absolute path
    * if it exists and passes the security check, or null otherwise.
-   * @param {string} relativePath path relative to HTML folder (without extension)
-   * @param {string} ext extension to append (e.g. '.html', '.plain.html')
+   * @param {string} relativePath path relative to HTML folder
    * @returns {Promise<string|null>} absolute path, or null if missing/invalid
    */
-  async resolveCandidate(relativePath, ext) {
+  async resolveCandidate(relativePath) {
     const file = path.resolve(
       this._project.directory,
       this._htmlFolder,
-      `${relativePath}${ext}`,
+      relativePath,
     );
 
     if (!utils.validatePathSecurity(file, this._project.directory)) {
@@ -244,11 +243,6 @@ export class HelixServer extends BaseServer {
    * @returns {Promise<{file: string, isPlain: boolean}|null>} resolved file info or null
    */
   async resolveHtmlFolderFile(relativePath) {
-    // Security check: prevent path traversal with /../ anywhere in the path
-    if (relativePath.includes('/../')) {
-      return null;
-    }
-
     // Don't process if it already has an extension
     if (relativePath.includes('.')) {
       return null;
@@ -260,7 +254,7 @@ export class HelixServer extends BaseServer {
 
     for (const ext of candidates) {
       // eslint-disable-next-line no-await-in-loop
-      const file = await this.resolveCandidate(relativePath, ext);
+      const file = await this.resolveCandidate(`${relativePath}${ext}`);
       if (file) {
         return { file, isPlain: ext === '.plain.html' };
       }

--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -26,6 +26,11 @@ import { transformContentMetadataHtml } from '../content/content-metadata-html.j
 const LOGIN_ROUTE = '/.aem/cli/login';
 const LOGIN_ACK_ROUTE = '/.aem/cli/login/ack';
 
+// HTML folder candidate extensions, in lookup order.
+// First entry takes precedence when multiple candidates exist on disk.
+const HTML_FOLDER_EXTENSIONS = ['.html', '.plain.html'];
+const HTML_FOLDER_EXTENSIONS_PREFER_PLAIN = [...HTML_FOLDER_EXTENSIONS].reverse();
+
 /**
  * @param {import('express').Request} req
  * @param {import('./RequestContext.js').default} ctx
@@ -250,8 +255,8 @@ export class HelixServer extends BaseServer {
     }
 
     const candidates = this._preferPlainHtml
-      ? ['.plain.html', '.html']
-      : ['.html', '.plain.html'];
+      ? HTML_FOLDER_EXTENSIONS_PREFER_PLAIN
+      : HTML_FOLDER_EXTENSIONS;
 
     for (const ext of candidates) {
       // eslint-disable-next-line no-await-in-loop

--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -65,6 +65,11 @@ export default class UpCommand extends AbstractServerCommand {
     return this;
   }
 
+  withPreferPlainHtml(value) {
+    this._preferPlainHtml = value;
+    return this;
+  }
+
   async doStop() {
     await super.doStop();
     if (this._watcher) {
@@ -118,7 +123,8 @@ export default class UpCommand extends AbstractServerCommand {
       .withSiteToken(this._siteToken)
       .withCookies(this._cookies)
       .withHtmlFolder(this._htmlFolder)
-      .withHtmlMount(this._htmlMount);
+      .withHtmlMount(this._htmlMount)
+      .withPreferPlainHtml(this._preferPlainHtml);
 
     this.log.info(chalk`{yellow     ___    ________  ___                          __      __ v${pkgJson.version}}`);
     this.log.info(chalk`{yellow    /   |  / ____/  |/  /  _____(_)___ ___  __  __/ /___ _/ /_____  _____}`);

--- a/src/up.js
+++ b/src/up.js
@@ -125,6 +125,12 @@ export default function up() {
           describe: 'URL path where html-folder files are served (e.g., / for root). Defaults to /FOLDER.',
           type: 'string',
         })
+        .option('prefer-plain-html', {
+          alias: 'preferPlainHtml',
+          describe: 'When --html-folder is set, prefer <stem>.plain.html over <stem>.html if both exist.',
+          type: 'boolean',
+          default: false,
+        })
 
         .help();
     },
@@ -153,6 +159,7 @@ export default function up() {
         .withCookies(argv.cookies)
         .withHtmlFolder(argv.htmlFolder)
         .withHtmlMount(argv.htmlMount)
+        .withPreferPlainHtml(argv.preferPlainHtml)
         .run();
     },
   };

--- a/test/server-html-folder.test.js
+++ b/test/server-html-folder.test.js
@@ -1659,7 +1659,7 @@ describe('Helix Server - HTML Folder', () => {
       const filePath = path.join(cwd, 'forms', 'foo.html');
       await fs.writeFile(filePath, '<html></html>');
 
-      const resolved = await project.server.resolveCandidate('foo', '.html');
+      const resolved = await project.server.resolveCandidate('foo.html');
       assert.equal(resolved, filePath);
     });
 
@@ -1668,21 +1668,21 @@ describe('Helix Server - HTML Folder', () => {
       const filePath = path.join(cwd, 'forms', 'foo.plain.html');
       await fs.writeFile(filePath, '<h1>plain</h1>');
 
-      const resolved = await project.server.resolveCandidate('foo', '.plain.html');
+      const resolved = await project.server.resolveCandidate('foo.plain.html');
       assert.equal(resolved, filePath);
     });
 
     it('returns null when the candidate file does not exist', async () => {
       const { project } = await makeProject();
-      assert.equal(await project.server.resolveCandidate('missing', '.html'), null);
-      assert.equal(await project.server.resolveCandidate('missing', '.plain.html'), null);
+      assert.equal(await project.server.resolveCandidate('missing.html'), null);
+      assert.equal(await project.server.resolveCandidate('missing.plain.html'), null);
     });
 
     it('does not fall back to the .plain.html sibling', async () => {
       const { project, cwd } = await makeProject();
       await fs.writeFile(path.join(cwd, 'forms', 'foo.plain.html'), '<h1>plain</h1>');
 
-      const resolved = await project.server.resolveCandidate('foo', '.html');
+      const resolved = await project.server.resolveCandidate('foo.html');
       assert.equal(resolved, null);
     });
 
@@ -1690,13 +1690,13 @@ describe('Helix Server - HTML Folder', () => {
       const { project, cwd } = await makeProject();
       await fs.mkdir(path.join(cwd, 'forms', 'foo.html'), { recursive: true });
 
-      const resolved = await project.server.resolveCandidate('foo', '.html');
+      const resolved = await project.server.resolveCandidate('foo.html');
       assert.equal(resolved, null);
     });
 
     it('returns null when the resolved path escapes the project directory', async () => {
       const { project } = await makeProject();
-      const resolved = await project.server.resolveCandidate('../../etc/passwd', '.html');
+      const resolved = await project.server.resolveCandidate('../../etc/passwd.html');
       assert.equal(resolved, null);
     });
   });

--- a/test/server-html-folder.test.js
+++ b/test/server-html-folder.test.js
@@ -1637,4 +1637,67 @@ describe('Helix Server - HTML Folder', () => {
       }
     });
   });
+
+  describe('resolveCandidate helper', () => {
+    async function makeProject() {
+      const cwd = await setupProject(
+        path.join(__rootdir, 'test', 'fixtures', 'project'),
+        testRoot,
+      );
+      await fs.mkdir(path.join(cwd, 'forms'), { recursive: true });
+      const project = new HelixProject()
+        .withCwd(cwd)
+        .withLogger(console)
+        .withHttpPort(0)
+        .withHtmlFolder('forms');
+      await project.init();
+      return { project, cwd };
+    }
+
+    it('returns the absolute path when an .html candidate exists', async () => {
+      const { project, cwd } = await makeProject();
+      const filePath = path.join(cwd, 'forms', 'foo.html');
+      await fs.writeFile(filePath, '<html></html>');
+
+      const resolved = await project.server.resolveCandidate('foo', '.html');
+      assert.equal(resolved, filePath);
+    });
+
+    it('returns the absolute path when a .plain.html candidate exists', async () => {
+      const { project, cwd } = await makeProject();
+      const filePath = path.join(cwd, 'forms', 'foo.plain.html');
+      await fs.writeFile(filePath, '<h1>plain</h1>');
+
+      const resolved = await project.server.resolveCandidate('foo', '.plain.html');
+      assert.equal(resolved, filePath);
+    });
+
+    it('returns null when the candidate file does not exist', async () => {
+      const { project } = await makeProject();
+      assert.equal(await project.server.resolveCandidate('missing', '.html'), null);
+      assert.equal(await project.server.resolveCandidate('missing', '.plain.html'), null);
+    });
+
+    it('does not fall back to the .plain.html sibling', async () => {
+      const { project, cwd } = await makeProject();
+      await fs.writeFile(path.join(cwd, 'forms', 'foo.plain.html'), '<h1>plain</h1>');
+
+      const resolved = await project.server.resolveCandidate('foo', '.html');
+      assert.equal(resolved, null);
+    });
+
+    it('returns null when the candidate path is a directory', async () => {
+      const { project, cwd } = await makeProject();
+      await fs.mkdir(path.join(cwd, 'forms', 'foo.html'), { recursive: true });
+
+      const resolved = await project.server.resolveCandidate('foo', '.html');
+      assert.equal(resolved, null);
+    });
+
+    it('returns null when the resolved path escapes the project directory', async () => {
+      const { project } = await makeProject();
+      const resolved = await project.server.resolveCandidate('../../etc/passwd', '.html');
+      assert.equal(resolved, null);
+    });
+  });
 });

--- a/test/server-html-folder.test.js
+++ b/test/server-html-folder.test.js
@@ -302,6 +302,73 @@ describe('Helix Server - HTML Folder', () => {
     }
   });
 
+  it('with --prefer-plain-html, .plain.html takes precedence over .html', async () => {
+    const cwd = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
+
+    // Create drafts folder with both .html and .plain.html
+    const draftsFolder = path.join(cwd, 'drafts');
+    await fs.mkdir(draftsFolder, { recursive: true });
+    await fs.writeFile(path.join(draftsFolder, 'priority.html'), '<html><body>Regular HTML</body></html>');
+    await fs.writeFile(path.join(draftsFolder, 'priority.plain.html'), '<p>Plain HTML</p>');
+
+    // Mock the remote head.html request (needed when serving .plain.html)
+    nock('https://main--foo--bar.aem.page')
+      .get('/head.html')
+      .reply(404);
+
+    const project = new HelixProject()
+      .withCwd(cwd)
+      .withLogger(console)
+      .withHttpPort(0)
+      .withProxyUrl('https://main--foo--bar.aem.page/')
+      .withHtmlFolder('drafts')
+      .withPreferPlainHtml(true);
+
+    await project.init();
+    try {
+      await project.start();
+
+      const response = await fetch(`http://127.0.0.1:${project.server.port}/drafts/priority`);
+      assert.equal(response.status, 200);
+
+      const content = await response.text();
+      assert.ok(content.includes('<p>Plain HTML</p>'), 'Should serve .plain.html content');
+      assert.ok(!content.includes('Regular HTML'), 'Should not serve .html file');
+    } finally {
+      await project.stop();
+    }
+  });
+
+  it('with --prefer-plain-html, falls back to .html when .plain.html missing', async () => {
+    const cwd = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
+
+    // Only .html exists, no .plain.html sibling
+    const draftsFolder = path.join(cwd, 'drafts');
+    await fs.mkdir(draftsFolder, { recursive: true });
+    await fs.writeFile(path.join(draftsFolder, 'fallback.html'), '<html><body>Regular HTML</body></html>');
+
+    const project = new HelixProject()
+      .withCwd(cwd)
+      .withLogger(console)
+      .withHttpPort(0)
+      .withProxyUrl('https://main--foo--bar.aem.page/')
+      .withHtmlFolder('drafts')
+      .withPreferPlainHtml(true);
+
+    await project.init();
+    try {
+      await project.start();
+
+      const response = await fetch(`http://127.0.0.1:${project.server.port}/drafts/fallback`);
+      assert.equal(response.status, 200);
+
+      const content = await response.text();
+      assert.ok(content.includes('Regular HTML'), 'Should serve .html file as fallback');
+    } finally {
+      await project.stop();
+    }
+  });
+
   it('.plain.html files support live reload injection', async () => {
     const cwd = await setupProject(path.join(__rootdir, 'test', 'fixtures', 'project'), testRoot);
 

--- a/test/up-cli.test.js
+++ b/test/up-cli.test.js
@@ -54,6 +54,7 @@ describe('hlx up', () => {
     mockUp.withSiteToken.returnsThis();
     mockUp.withHtmlFolder.returnsThis();
     mockUp.withHtmlMount.returnsThis();
+    mockUp.withPreferPlainHtml.returnsThis();
     mockUp.run.returnsThis();
     cli = (await new CLI().initCommands()).withCommandExecutor('up', mockUp);
   });
@@ -188,6 +189,24 @@ describe('hlx up', () => {
   it('aem up can use htmlFolder camelCase option', async () => {
     await cli.run(['up', '--htmlFolder', 'drafts']);
     sinon.assert.calledWith(mockUp.withHtmlFolder, 'drafts');
+    sinon.assert.calledOnce(mockUp.run);
+  });
+
+  it('aem up can set --prefer-plain-html', async () => {
+    await cli.run(['up', '--prefer-plain-html']);
+    sinon.assert.calledWith(mockUp.withPreferPlainHtml, true);
+    sinon.assert.calledOnce(mockUp.run);
+  });
+
+  it('aem up can use preferPlainHtml camelCase option', async () => {
+    await cli.run(['up', '--preferPlainHtml']);
+    sinon.assert.calledWith(mockUp.withPreferPlainHtml, true);
+    sinon.assert.calledOnce(mockUp.run);
+  });
+
+  it('aem up defaults --prefer-plain-html to false', async () => {
+    await cli.run(['up']);
+    sinon.assert.calledWith(mockUp.withPreferPlainHtml, false);
     sinon.assert.calledOnce(mockUp.run);
   });
 });


### PR DESCRIPTION
Add an opt-in --prefer-plain-html flag to aem up so .plain.html wins over .html sibling in --html-folder mode

## Related Issues
https://github.com/Adobe-AEM-Foundation/aem-experience-catalyst/issues/1129



