### PR TITLE
fix(ci): upgrade playwright to 1.60.0 to fix install hang on Node.js 24.16.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,11 +24,22 @@ jobs:
       - run: npm i
 
       # Sub-project setup and testing (conditional)
+      - name: Cache Playwright browsers
+        if: hashFiles('packages/browser-injectables/**') != ''
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('packages/browser-injectables/package-lock.json') }}
+
       - name: Install browser injectable dependencies
         if: hashFiles('packages/browser-injectables/**') != ''
         run: cd packages/browser-injectables && npm ci
 
-      - name: Install Playwright dependencies for browser injectables
+      - name: Install Playwright browsers
+        if: hashFiles('packages/browser-injectables/**') != ''
+        run: cd packages/browser-injectables && npx playwright install
+
+      - name: Install Playwright system dependencies
         if: hashFiles('packages/browser-injectables/**') != ''
         run: cd packages/browser-injectables && npx playwright install-deps
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,13 +35,9 @@ jobs:
         if: hashFiles('packages/browser-injectables/**') != ''
         run: cd packages/browser-injectables && npm ci
 
-      - name: Install Playwright browsers
+      - name: Install Playwright browsers (chromium, firefox, webkit)
         if: hashFiles('packages/browser-injectables/**') != ''
-        run: cd packages/browser-injectables && npx playwright install
-
-      - name: Install Playwright system dependencies
-        if: hashFiles('packages/browser-injectables/**') != ''
-        run: cd packages/browser-injectables && npx playwright install-deps
+        run: cd packages/browser-injectables && npx playwright install --with-deps chromium firefox webkit
 
       - run: git config --global user.email "test@project-helix.io" && git config --global user.name "Test Build"
       - run: git config --global protocol.file.allow always

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js 24.x
@@ -38,10 +37,6 @@ jobs:
 
       - name: Install Playwright browsers (chromium, firefox, webkit)
         if: hashFiles('packages/browser-injectables/**') != ''
-        timeout-minutes: 10
-        env:
-          PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: 30000
-          DEBIAN_FRONTEND: noninteractive
         run: cd packages/browser-injectables && npx playwright install --with-deps chromium firefox webkit
 
       - run: git config --global user.email "test@project-helix.io" && git config --global user.name "Test Build"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,6 +15,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js 24.x
@@ -37,6 +38,10 @@ jobs:
 
       - name: Install Playwright browsers (chromium, firefox, webkit)
         if: hashFiles('packages/browser-injectables/**') != ''
+        timeout-minutes: 10
+        env:
+          PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: 30000
+          DEBIAN_FRONTEND: noninteractive
         run: cd packages/browser-injectables && npx playwright install --with-deps chromium firefox webkit
 
       - run: git config --global user.email "test@project-helix.io" && git config --global user.name "Test Build"

--- a/packages/browser-injectables/package-lock.json
+++ b/packages/browser-injectables/package-lock.json
@@ -18,7 +18,8 @@
         "@web/test-runner": "0.20.2",
         "@web/test-runner-junit-reporter": "0.8.0",
         "@web/test-runner-mocha": "0.9.0",
-        "@web/test-runner-playwright": "0.11.1"
+        "@web/test-runner-playwright": "0.11.1",
+        "playwright": "1.60.0"
       }
     },
     "node_modules/@adobe/eslint-config-helix": {
@@ -5420,13 +5421,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
-      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.56.0"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5439,9 +5440,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
-      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/packages/browser-injectables/package.json
+++ b/packages/browser-injectables/package.json
@@ -18,7 +18,8 @@
     "@web/test-runner": "0.20.2",
     "@web/test-runner-playwright": "0.11.1",
     "@web/test-runner-junit-reporter": "0.8.0",
-    "@web/test-runner-mocha": "0.9.0"
+    "@web/test-runner-mocha": "0.9.0",
+    "playwright": "1.60.0"
   },
   "dependencies": {
     "livereload-js": "4.0.2"

--- a/packages/browser-injectables/package.json
+++ b/packages/browser-injectables/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "test": "web-test-runner",
     "test:watch": "web-test-runner --watch",
-    "postinstall": "npm run copy-vendor && npx playwright install",
+    "postinstall": "npm run copy-vendor",
     "copy-vendor": "node scripts/copy-vendor.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Root cause

`node-version: '24.x'` in the workflow recently resolved to **Node.js 24.16.0**, which introduced a regression in `extract-zip` ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487)). After a browser zip downloads to 100%, extraction hangs indefinitely with no error or output. `@web/test-runner-playwright@0.11.1` bundled `playwright@1.56.0` which is affected; **1.60.0 contains the fix**.

## Changes

- Pin `playwright@1.60.0` in `devDependencies` to override peer dep resolution and pick up the extraction fix
- Move `npx playwright install` out of `postinstall` into an explicit CI step so `npm ci` stays fast and the install is visible in the job log
- Cache `~/.cache/ms-playwright` keyed on `package-lock.json` to avoid re-downloading browsers on every run
- Use `--with-deps chromium firefox webkit` to install browsers and system libraries in one explicit step

## Test plan

- [ ] CI passes end-to-end on this PR
- [ ] "Install Playwright browsers" step completes without hanging
- [ ] Second run hits the cache and the step completes in seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)