### PR TITLE
fix(content): use org/site terminology and centralize config reading

### DIFF
--- a/src/content/clone.cmd.js
+++ b/src/content/clone.cmd.js
@@ -101,14 +101,14 @@ export default class CloneCommand {
       throw new Error('Clone root path was not set (internal error).');
     }
 
-    // 1. Resolve owner/repo from git remote
+    // 1. Resolve org/site from git remote (GitHub owner/repo → da.live org/site)
     const originUrl = await GitUtils.getOriginURL(this._dir);
     if (!originUrl) {
       throw new Error('No git remote found. Run `aem content clone` inside an AEM project directory.');
     }
-    const owner = originUrl.owner.toLowerCase();
-    const repo = originUrl.repo.toLowerCase();
-    log.info(`Cloning content from da.live: ${owner}/${repo}${this._rootPath === '/' ? '' : ` @ ${this._rootPath}`}`);
+    const org = originUrl.owner.toLowerCase();
+    const site = originUrl.repo.toLowerCase();
+    log.info(`Cloning content from da.live: ${org}/${site}${this._rootPath === '/' ? '' : ` @ ${this._rootPath}`}`);
 
     // 2. Ensure target path is available (do not create content/ until after file count is known)
     const contentDir = path.resolve(this._dir, CONTENT_DIR);
@@ -126,7 +126,7 @@ export default class CloneCommand {
     const client = new DaClient(token);
     log.info('Fetching file list...');
     const showDiscoveryProgress = process.stdout.isTTY;
-    const files = await client.listAll(owner, repo, this._rootPath, showDiscoveryProgress
+    const files = await client.listAll(org, site, this._rootPath, showDiscoveryProgress
       ? (n) => {
         process.stdout.write(`\r  ${n} file(s) discovered so far...`);
       }
@@ -148,15 +148,15 @@ export default class CloneCommand {
     const downloadResults = await processQueue(
       files,
       async (file) => {
-        const prefix = `/${owner}/${repo}`;
+        const prefix = `/${org}/${site}`;
         if (!file.path.startsWith(prefix)) {
-          log.warn(`  skip (unexpected path, missing owner/repo prefix): ${file.path}`);
+          log.warn(`  skip (unexpected path, missing org/site prefix): ${file.path}`);
           return { status: 404 };
         }
         const daPath = file.path.slice(prefix.length) || '/';
         const localPath = path.join(contentDir, ...daPath.split('/').filter(Boolean));
         try {
-          const res = await client.getSource(owner, repo, daPath);
+          const res = await client.getSource(org, site, daPath);
           if (!res) {
             log.warn(`  skip (not found): ${daPath}`);
             return { status: 404 };
@@ -195,7 +195,7 @@ export default class CloneCommand {
     await git.commit({
       fs,
       dir: contentDir,
-      message: `clone: ${owner}/${repo}${this._rootPath === '/' ? '' : ` (${this._rootPath})`}`,
+      message: `clone: ${org}/${site}${this._rootPath === '/' ? '' : ` (${this._rootPath})`}`,
       author: GIT_AUTHOR,
     });
     const headOid = await git.resolveRef({ fs, dir: contentDir, ref: 'HEAD' });
@@ -203,8 +203,8 @@ export default class CloneCommand {
 
     // 8. Write config (not tracked by git)
     await fse.writeJson(path.join(contentDir, CONFIG_FILE), {
-      owner,
-      repo,
+      org,
+      site,
       rootPath: this._rootPath,
     }, { spaces: 2 });
 

--- a/src/content/content-shared.js
+++ b/src/content/content-shared.js
@@ -10,6 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
+import path from 'path';
+import fse from 'fs-extra';
+
 export const CONTENT_DIR = 'content';
 export const CONFIG_FILE = '.da-config.json';
 export const GIT_AUTHOR = { name: 'aem-cli', email: 'aem-cli@adobe.com' };
@@ -21,6 +24,28 @@ export const LARGE_CLONE_FILE_THRESHOLD = 10000;
  * Parallelism for da.live I/O: recursive list fan-out, clone downloads, push uploads/deletes.
  */
 export const CONTENT_IO_CONCURRENCY = 10;
+
+/**
+ * Reads and normalizes the content config from a content directory.
+ * Accepts both current keys (org/site) and legacy keys (owner/repo) written
+ * by earlier versions of clone. org/site take priority when both are present.
+ * @param {string} contentDir - absolute path to the content/ directory
+ * @returns {Promise<{org: string, site: string, rootPath: string|undefined}>}
+ * @throws if the config file is missing or org/site cannot be resolved
+ */
+export async function readContentConfig(contentDir) {
+  const configPath = path.join(contentDir, CONFIG_FILE);
+  if (!await fse.pathExists(configPath)) {
+    throw new Error(`No config found at ${configPath}. Run 'aem content clone' first.`);
+  }
+  const raw = await fse.readJson(configPath);
+  const org = (raw.org || raw.owner || '').toLowerCase();
+  const site = (raw.site || raw.repo || '').toLowerCase();
+  if (!org || !site) {
+    throw new Error(`Invalid config: org and site are required in ${configPath}.`);
+  }
+  return { org, site, rootPath: raw.rootPath };
+}
 
 /**
  * Normalizes a da.live path: leading slash, no trailing slash except root.

--- a/src/content/da-api.js
+++ b/src/content/da-api.js
@@ -39,12 +39,12 @@ export class DaClient {
   /**
    * Lists the contents of a directory, following {@link LIST_CONTINUATION_HEADER} until complete.
    * @param {string} org
-   * @param {string} repo
+   * @param {string} site
    * @param {string} daPath - path starting with /
    * @returns {Promise<Array<{path, name, ext?, lastModified}>>}
    */
-  async list(org, repo, daPath) {
-    const url = `${DA_ADMIN}/list/${org}/${repo}${daPath}`;
+  async list(org, site, daPath) {
+    const url = `${DA_ADMIN}/list/${org}/${site}${daPath}`;
     const aggregated = [];
     let continuation = null;
 
@@ -81,13 +81,13 @@ export class DaClient {
   /**
    * Recursively lists all files under a path using a non-recursive queue-based approach.
    * @param {string} org
-   * @param {string} repo
+   * @param {string} site
    * @param {string} [daPath='/']
    * @param {(discoveredCount: number) => void} [onDiscovered] - cumulative file count per discovery
    * @returns {Promise<Array<{path, name, ext, lastModified}>>}
    */
-  async listAll(org, repo, daPath = '/', onDiscovered = undefined) {
-    const prefix = `/${org}/${repo}`;
+  async listAll(org, site, daPath = '/', onDiscovered = undefined) {
+    const prefix = `/${org}/${site}`;
     const files = [];
     let dirsToProcess = [daPath];
 
@@ -97,7 +97,7 @@ export class DaClient {
       await processQueue(
         dirsToProcess,
         async (currentPath) => {
-          const items = await this.list(org, repo, currentPath);
+          const items = await this.list(org, site, currentPath);
           for (const item of items) {
             if (item.ext !== undefined) {
               files.push(item);
@@ -119,10 +119,13 @@ export class DaClient {
 
   /**
    * Fetches the raw content of a file.
+   * @param {string} org
+   * @param {string} site
+   * @param {string} daPath
    * @returns {Promise<Response|null>}
    */
-  async getSource(org, repo, daPath) {
-    const url = `${DA_ADMIN}/source/${org}/${repo}${daPath}`;
+  async getSource(org, site, daPath) {
+    const url = `${DA_ADMIN}/source/${org}/${site}${daPath}`;
     const res = await this.fetch(url, { headers: this.authHeader });
     if (res.status === 401) {
       throw new Error('Unauthorized: invalid or missing token');
@@ -139,14 +142,14 @@ export class DaClient {
   /**
    * Uploads a file via PUT.
    * @param {string} org
-   * @param {string} repo
+   * @param {string} site
    * @param {string} daPath
    * @param {Buffer} buffer
    * @param {string} contentType
    * @returns {Promise<object>} API response body
    */
-  async putSource(org, repo, daPath, buffer, contentType) {
-    const url = `${DA_ADMIN}/source/${org}/${repo}${daPath}`;
+  async putSource(org, site, daPath, buffer, contentType) {
+    const url = `${DA_ADMIN}/source/${org}/${site}${daPath}`;
     const res = await this.fetch(url, {
       method: 'PUT',
       headers: { ...this.authHeader, 'Content-Type': contentType },
@@ -165,8 +168,8 @@ export class DaClient {
    * Deletes a file or folder. Idempotent: 404 is treated as success.
    * Throws on transport or server errors so callers don't silently treat them as success.
    */
-  async deleteSource(org, repo, daPath) {
-    const url = `${DA_ADMIN}/source/${org}/${repo}${daPath}`;
+  async deleteSource(org, site, daPath) {
+    const url = `${DA_ADMIN}/source/${org}/${site}${daPath}`;
     const res = await this.fetch(url, {
       method: 'DELETE',
       headers: this.authHeader,
@@ -183,12 +186,12 @@ export class DaClient {
   /**
    * Returns the current lastModified for a file via a HEAD request.
    * @param {string} org
-   * @param {string} repo
+   * @param {string} site
    * @param {string} daPath - e.g. /blog/post.html
    * @returns {Promise<number|null>}
    */
-  async getRemoteLastModified(org, repo, daPath) {
-    const url = `${DA_ADMIN}/source/${org}/${repo}${daPath}`;
+  async getRemoteLastModified(org, site, daPath) {
+    const url = `${DA_ADMIN}/source/${org}/${site}${daPath}`;
     const res = await this.fetch(url, { method: 'HEAD', headers: this.authHeader });
     if (res.status === 401) {
       throw new Error('Unauthorized: invalid or missing token');

--- a/src/content/diff.cmd.js
+++ b/src/content/diff.cmd.js
@@ -17,7 +17,7 @@ import { createTwoFilesPatch } from 'diff';
 import chalk from 'chalk-template';
 import { DaClient } from './da-api.js';
 import { getValidToken } from './da-auth.js';
-import { CONTENT_DIR, CONFIG_FILE } from './content-shared.js';
+import { CONTENT_DIR, readContentConfig } from './content-shared.js';
 
 function printPatch(patch) {
   for (const line of patch.split('\n')) {
@@ -60,12 +60,7 @@ export default class DiffCommand {
   async run() {
     const { log } = this;
     const contentDir = path.resolve(this._dir, CONTENT_DIR);
-    const configPath = path.join(contentDir, CONFIG_FILE);
-
-    if (!await fse.pathExists(configPath)) {
-      throw new Error('No config found. Run \'aem content clone\' first.');
-    }
-    const { org, repo } = await fse.readJson(configPath);
+    const { org, site } = await readContentConfig(contentDir);
 
     const matrix = await git.statusMatrix({ fs, dir: contentDir });
     let changedPaths = matrix
@@ -98,7 +93,7 @@ export default class DiffCommand {
         ? await fse.readFile(localPath)
         : Buffer.from('');
 
-      const remoteRes = await client.getSource(org, repo, daPath);
+      const remoteRes = await client.getSource(org, site, daPath);
 
       const localText = localBuffer.toString('utf-8');
       const remoteText = remoteRes ? await remoteRes.text() : '';

--- a/src/content/merge.cmd.js
+++ b/src/content/merge.cmd.js
@@ -16,7 +16,7 @@ import git from 'isomorphic-git';
 import { diff3Merge } from 'node-diff3'; // eslint-disable-line import/no-unresolved
 import { DaClient } from './da-api.js';
 import { getValidToken } from './da-auth.js';
-import { CONTENT_DIR, CONFIG_FILE } from './content-shared.js';
+import { CONTENT_DIR, readContentConfig } from './content-shared.js';
 
 /**
  * 3-way merge using diff3 algorithm.
@@ -69,12 +69,7 @@ export default class MergeCommand {
   async run() {
     const { log } = this;
     const contentDir = path.resolve(this._dir, CONTENT_DIR);
-    const configPath = path.join(contentDir, CONFIG_FILE);
-
-    if (!await fse.pathExists(configPath)) {
-      throw new Error('No config found. Run \'aem content clone\' first.');
-    }
-    const { org, repo } = await fse.readJson(configPath);
+    const { org, site } = await readContentConfig(contentDir);
 
     // Find locally changed files via git
     const matrix = await git.statusMatrix({ fs, dir: contentDir });
@@ -112,7 +107,7 @@ export default class MergeCommand {
       // eslint-disable-next-line no-await-in-loop
       const [localBuffer, remoteRes, blobResult] = await Promise.all([
         fse.readFile(localPath),
-        client.getSource(org, repo, daPath),
+        client.getSource(org, site, daPath),
         git.readBlob({
           fs, dir: contentDir, oid: headCommit.oid, filepath: relPath,
         })

--- a/src/content/push.cmd.js
+++ b/src/content/push.cmd.js
@@ -18,8 +18,8 @@ import { DaClient, getContentType } from './da-api.js';
 import { getValidToken } from './da-auth.js';
 import {
   CONTENT_DIR,
-  CONFIG_FILE,
   CONTENT_IO_CONCURRENCY,
+  readContentConfig,
 } from './content-shared.js';
 import {
   resolveSyncedOid,
@@ -67,19 +67,19 @@ export default class PushCommand {
    * Checks for conflicts between local changes and remote modifications.
    * @param {DaClient} client
    * @param {string} org
-   * @param {string} repo
+   * @param {string} site
    * @param {string[]} modified
    * @param {string[]} deleted
    * @param {number} lastSyncTime
    * @returns {Promise<boolean>} true if the push should be aborted
    */
-  async _checkConflicts(client, org, repo, modified, deleted, lastSyncTime) {
+  async _checkConflicts(client, org, site, modified, deleted, lastSyncTime) {
     const { log } = this;
     const conflicts = [];
 
     for (const daPath of [...modified, ...deleted]) {
       // eslint-disable-next-line no-await-in-loop
-      const remoteLastModified = await client.getRemoteLastModified(org, repo, daPath);
+      const remoteLastModified = await client.getRemoteLastModified(org, site, daPath);
       if (remoteLastModified != null && remoteLastModified > lastSyncTime) {
         conflicts.push({ daPath, remoteDate: new Date(remoteLastModified).toLocaleString() });
       }
@@ -105,12 +105,12 @@ export default class PushCommand {
    * Uploads added and modified files to da.live.
    * @param {DaClient} client
    * @param {string} org
-   * @param {string} repo
+   * @param {string} site
    * @param {string} contentDir
    * @param {string[]} targets
    * @returns {Promise<{ pushed: number, errors: number }>}
    */
-  async _uploadFiles(client, org, repo, contentDir, targets) {
+  async _uploadFiles(client, org, site, contentDir, targets) {
     const { log } = this;
     let pushed = 0;
     let errors = 0;
@@ -123,7 +123,7 @@ export default class PushCommand {
         const ext = daPath.split('.').pop();
         try {
           const buffer = await fse.readFile(localPath);
-          await client.putSource(org, repo, daPath, buffer, getContentType(ext));
+          await client.putSource(org, site, daPath, buffer, getContentType(ext));
           log.info(`  ✓ ${daPath}`);
           return { ok: true };
         } catch (err) {
@@ -148,11 +148,11 @@ export default class PushCommand {
    * Deletes files from da.live.
    * @param {DaClient} client
    * @param {string} org
-   * @param {string} repo
+   * @param {string} site
    * @param {string[]} deleted
    * @returns {Promise<{ pushed: number, errors: number }>}
    */
-  async _deleteFiles(client, org, repo, deleted) {
+  async _deleteFiles(client, org, site, deleted) {
     const { log } = this;
     let pushed = 0;
     let errors = 0;
@@ -162,7 +162,7 @@ export default class PushCommand {
       [...deleted],
       async (daPath) => {
         try {
-          await client.deleteSource(org, repo, daPath);
+          await client.deleteSource(org, site, daPath);
           log.info(`  ✓ deleted ${daPath}`);
           return { ok: true };
         } catch (err) {
@@ -186,12 +186,7 @@ export default class PushCommand {
   async run() {
     const { log } = this;
     const contentDir = path.resolve(this._dir, CONTENT_DIR);
-    const configPath = path.join(contentDir, CONFIG_FILE);
-
-    if (!await fse.pathExists(configPath)) {
-      throw new Error(`No config found at ${configPath}. Run 'aem content clone' first.`);
-    }
-    const { org, repo } = await fse.readJson(configPath);
+    const { org, site } = await readContentConfig(contentDir);
 
     const matrix = await git.statusMatrix({ fs, dir: contentDir });
     if (statusMatrixHasUncommitted(matrix)) {
@@ -228,7 +223,7 @@ export default class PushCommand {
 
     const token = await getValidToken(log, this._token, this._dir);
 
-    log.info(`Pushing content to da.live: ${org}/${repo}`);
+    log.info(`Pushing content to da.live: ${org}/${site}`);
     log.info(`${added.length} added, ${modified.length} modified, ${deleted.length} deleted`);
 
     const client = new DaClient(token);
@@ -236,7 +231,7 @@ export default class PushCommand {
     const shouldAbort = await this._checkConflicts(
       client,
       org,
-      repo,
+      site,
       modified,
       deleted,
       lastSyncTime,
@@ -271,12 +266,12 @@ export default class PushCommand {
     const {
       pushed: putPushed,
       errors: putErrors,
-    } = await this._uploadFiles(client, org, repo, contentDir, [...added, ...modified]);
+    } = await this._uploadFiles(client, org, site, contentDir, [...added, ...modified]);
 
     const {
       pushed: deletePushed,
       errors: deleteErrors,
-    } = await this._deleteFiles(client, org, repo, deleted);
+    } = await this._deleteFiles(client, org, site, deleted);
 
     const pushed = putPushed + deletePushed;
     const pushErrors = putErrors + deleteErrors;

--- a/src/content/status.cmd.js
+++ b/src/content/status.cmd.js
@@ -11,9 +11,8 @@
  */
 import fs from 'fs';
 import path from 'path';
-import fse from 'fs-extra';
 import git from 'isomorphic-git';
-import { CONTENT_DIR, CONFIG_FILE } from './content-shared.js';
+import { CONTENT_DIR, readContentConfig } from './content-shared.js';
 import { resolveSyncedOid, countCommitsAhead } from './content-git.js';
 
 export default class StatusCommand {
@@ -30,14 +29,9 @@ export default class StatusCommand {
   async run() {
     const { log } = this;
     const contentDir = path.resolve(this._dir, CONTENT_DIR);
-    const configPath = path.join(contentDir, CONFIG_FILE);
+    const { org, site } = await readContentConfig(contentDir);
 
-    if (!await fse.pathExists(configPath)) {
-      throw new Error('No config found. Run \'aem content clone\' first.');
-    }
-    const { org, repo } = await fse.readJson(configPath);
-
-    log.info(`On da.live: ${org}/${repo}`);
+    log.info(`On da.live: ${org}/${site}`);
     log.info(`Local content: ./${CONTENT_DIR}/\n`);
 
     const matrix = await git.statusMatrix({ fs, dir: contentDir });

--- a/test/content/clone.cmd.test.js
+++ b/test/content/clone.cmd.test.js
@@ -19,7 +19,12 @@ import git from 'isomorphic-git';
 import esmock from 'esmock';
 import { createTestRoot } from '../utils.js';
 import { makeLogger, createDaClientClass } from './content-test-utils.js';
-import { normalizeDaPath, CONTENT_DIR, LARGE_CLONE_FILE_THRESHOLD } from '../../src/content/content-shared.js';
+import {
+  normalizeDaPath,
+  readContentConfig,
+  CONTENT_DIR,
+  LARGE_CLONE_FILE_THRESHOLD,
+} from '../../src/content/content-shared.js';
 import { DA_SYNCED_REF } from '../../src/content/content-git.js';
 
 async function makeCloneCommand(testRoot, DaClientClass) {
@@ -116,6 +121,50 @@ describe('CloneCommand', () => {
     });
   });
 
+  describe('readContentConfig()', () => {
+    it('reads org and site from current config format', async () => {
+      await fse.writeJson(path.join(testRoot, '.da-config.json'), { org: 'myorg', site: 'mysite', rootPath: '/' });
+      const config = await readContentConfig(testRoot);
+      assert.strictEqual(config.org, 'myorg');
+      assert.strictEqual(config.site, 'mysite');
+      assert.strictEqual(config.rootPath, '/');
+    });
+
+    it('maps legacy owner/repo fields to org/site', async () => {
+      await fse.writeJson(path.join(testRoot, '.da-config.json'), { owner: 'myowner', repo: 'myrepo' });
+      const config = await readContentConfig(testRoot);
+      assert.strictEqual(config.org, 'myowner');
+      assert.strictEqual(config.site, 'myrepo');
+    });
+
+    it('gives org/site priority over owner/repo when both present', async () => {
+      await fse.writeJson(path.join(testRoot, '.da-config.json'), {
+        org: 'daorg', site: 'dasite', owner: 'ghowner', repo: 'ghrepo',
+      });
+      const config = await readContentConfig(testRoot);
+      assert.strictEqual(config.org, 'daorg');
+      assert.strictEqual(config.site, 'dasite');
+    });
+
+    it('normalizes org and site to lowercase', async () => {
+      await fse.writeJson(path.join(testRoot, '.da-config.json'), { org: 'MyOrg', site: 'My-Site' });
+      const config = await readContentConfig(testRoot);
+      assert.strictEqual(config.org, 'myorg');
+      assert.strictEqual(config.site, 'my-site');
+    });
+
+    it('normalizes legacy owner/repo to lowercase', async () => {
+      await fse.writeJson(path.join(testRoot, '.da-config.json'), { owner: 'MyOwner', repo: 'MyRepo' });
+      const config = await readContentConfig(testRoot);
+      assert.strictEqual(config.org, 'myowner');
+      assert.strictEqual(config.site, 'myrepo');
+    });
+
+    it('throws when config file is missing', async () => {
+      await assert.rejects(() => readContentConfig(testRoot), /No config found/);
+    });
+  });
+
   describe('run()', () => {
     it('throws when no git remote found', async () => {
       const mod = await esmock('../../src/content/clone.cmd.js', {
@@ -176,7 +225,7 @@ describe('CloneCommand', () => {
       assert.strictEqual(content, '<html>page</html>');
     });
 
-    it('writes .da-config.json with owner, repo, and rootPath', async () => {
+    it('writes .da-config.json with org, site, and rootPath', async () => {
       const cmd = await makeCloneCommand(testRoot, createDaClientClass());
       cmd.withRootPath('/blog');
       await cmd.run();
@@ -184,8 +233,8 @@ describe('CloneCommand', () => {
       const configPath = path.join(testRoot, CONTENT_DIR, '.da-config.json');
       assert.ok(await fse.pathExists(configPath));
       const config = await fse.readJson(configPath);
-      assert.strictEqual(config.owner, 'myowner');
-      assert.strictEqual(config.repo, 'myrepo');
+      assert.strictEqual(config.org, 'myowner');
+      assert.strictEqual(config.site, 'myrepo');
       assert.strictEqual(config.rootPath, '/blog');
     });
 
@@ -248,7 +297,7 @@ describe('CloneCommand', () => {
       const DaClientClass = createDaClientClass({
         files: [{ path: '/myowner/myrepo/ca/fr_ca/page.html', name: 'page.html', ext: 'html' }],
         sourceContent: '<html>x</html>',
-        onListAll: (owner, repo, daPath) => {
+        onListAll: (org, site, daPath) => {
           listedAt = daPath;
         },
       });
@@ -285,8 +334,8 @@ describe('CloneCommand', () => {
       assert.ok(await fse.pathExists(localPath), 'file should be downloaded despite case mismatch');
 
       const config = await fse.readJson(path.join(testRoot, CONTENT_DIR, '.da-config.json'));
-      assert.strictEqual(config.owner, 'myowner', 'owner should be stored lowercase');
-      assert.strictEqual(config.repo, 'myrepo', 'repo should be stored lowercase');
+      assert.strictEqual(config.org, 'myowner', 'org should be stored lowercase');
+      assert.strictEqual(config.site, 'myrepo', 'site should be stored lowercase');
     });
 
     it('refuses large clone without --yes when not interactive', async () => {

--- a/test/content/content-test-utils.js
+++ b/test/content/content-test-utils.js
@@ -32,7 +32,7 @@ export function makeLogger() {
  * Creates a content dir with a baseline git commit.
  * Writes .da-config.json (not tracked).
  */
-export async function setupContentDir(baseDir, org = 'myorg', repo = 'myrepo') {
+export async function setupContentDir(baseDir, org = 'myorg', site = 'mysite') {
   const contentDir = path.join(baseDir, CONTENT_DIR);
   await fse.ensureDir(path.join(contentDir, 'blog'));
 
@@ -47,11 +47,11 @@ export async function setupContentDir(baseDir, org = 'myorg', repo = 'myrepo') {
   await git.commit({
     fs,
     dir: contentDir,
-    message: `clone: ${org}/${repo}`,
+    message: `clone: ${org}/${site}`,
     author: GIT_AUTHOR,
   });
 
-  await fse.writeJson(path.join(contentDir, '.da-config.json'), { org, repo }, { spaces: 2 });
+  await fse.writeJson(path.join(contentDir, '.da-config.json'), { org, site }, { spaces: 2 });
 
   return contentDir;
 }
@@ -80,6 +80,7 @@ export async function stageAllAndCommit(contentDir, message) {
  * @param {number}  opts.remoteLastModified lastModified returned by getRemoteLastModified
  * @param {boolean} opts.putFails        if true, putSource throws
  * @param {boolean} opts.deleteFails     if true, deleteSource throws
+ * @param {Function} opts.onGetSource   called with (owner, repo, daPath) when getSource is called
  * @param {Function} opts.onPut         called with (daPath) when putSource is called
  * @param {Function} opts.onDelete      called with (daPath) when deleteSource is called
  */
@@ -88,9 +89,9 @@ export function createDaClientClass(opts = {}) {
     this.token = token;
   }
 
-  DaClientMock.prototype.listAll = async function listAll(org, repo, daPath, onDiscovered) {
+  DaClientMock.prototype.listAll = async function listAll(org, site, daPath, onDiscovered) {
     if (opts.onListAll) {
-      opts.onListAll(org, repo, daPath);
+      opts.onListAll(org, site, daPath);
     }
     const files = opts.files || [];
     if (onDiscovered) {
@@ -105,7 +106,10 @@ export function createDaClientClass(opts = {}) {
     return files;
   };
 
-  DaClientMock.prototype.getSource = async function getSource() {
+  DaClientMock.prototype.getSource = async function getSource(org, site, daPath) {
+    if (opts.onGetSource) {
+      opts.onGetSource(org, site, daPath);
+    }
     const content = opts.sourceContent !== undefined ? opts.sourceContent : '<html>remote</html>';
     if (content === null) {
       return null;
@@ -121,7 +125,7 @@ export function createDaClientClass(opts = {}) {
     return opts.remoteLastModified !== undefined ? opts.remoteLastModified : null;
   };
 
-  DaClientMock.prototype.putSource = async function putSource(org, repo, daPath) {
+  DaClientMock.prototype.putSource = async function putSource(org, site, daPath) {
     if (opts.putFails) {
       throw new Error(`PUT failed for ${daPath}`);
     }
@@ -131,7 +135,7 @@ export function createDaClientClass(opts = {}) {
     return {};
   };
 
-  DaClientMock.prototype.deleteSource = async function deleteSource(org, repo, daPath) {
+  DaClientMock.prototype.deleteSource = async function deleteSource(org, site, daPath) {
     if (opts.deleteFails) {
       throw new Error(`DELETE failed for ${daPath}`);
     }

--- a/test/content/da-api.test.js
+++ b/test/content/da-api.test.js
@@ -176,7 +176,7 @@ describe('DaClient', () => {
     });
 
     it('recurses into folders', async () => {
-      client.list = async (org, repo, daPath) => {
+      client.list = async (org, site, daPath) => {
         if (daPath === '/') {
           return [
             { path: '/org/repo/file.html', name: 'file.html', ext: 'html' },
@@ -202,7 +202,7 @@ describe('DaClient', () => {
 
     it('strips org/repo prefix when computing subfolder path', async () => {
       const listedPaths = [];
-      client.list = async (org, repo, daPath) => {
+      client.list = async (org, site, daPath) => {
         listedPaths.push(daPath);
         if (daPath === '/') {
           return [{ path: '/org/repo/nested', name: 'nested' }];
@@ -215,7 +215,7 @@ describe('DaClient', () => {
 
     it('invokes onDiscovered with cumulative count for each file', async () => {
       const counts = [];
-      client.list = async (org, repo, daPath) => {
+      client.list = async (org, site, daPath) => {
         if (daPath === '/') {
           return [
             { path: '/org/repo/a.html', name: 'a.html', ext: 'html' },

--- a/test/content/diff.cmd.test.js
+++ b/test/content/diff.cmd.test.js
@@ -164,5 +164,45 @@ describe('DiffCommand', () => {
         process.stdout.write = origWrite;
       }
     });
+
+    it('calls DA API with lowercase owner/repo when config uses owner field with mixed case', async () => {
+      const contentDir = await setupContentDir(testRoot);
+      await fse.writeJson(path.join(contentDir, '.da-config.json'), { owner: 'myOwner', repo: 'MyRepo' });
+      await fse.writeFile(path.join(contentDir, 'index.html'), 'changed');
+
+      const calls = [];
+      const DaClientClass = createDaClientClass({
+        onGetSource: (org, site) => calls.push({ org, site }),
+      });
+      const mod = await esmock('../../src/content/diff.cmd.js', {
+        '../../src/content/da-auth.js': { getValidToken: async () => 'token' },
+        '../../src/content/da-api.js': { DaClient: DaClientClass },
+      });
+      const Cmd = mod.default;
+      await new Cmd(makeLogger()).withDirectory(testRoot).run();
+
+      assert.ok(calls.length > 0);
+      assert.ok(calls.every((c) => c.org === 'myowner' && c.site === 'myrepo'));
+    });
+
+    it('calls DA API with lowercase owner/repo when config uses legacy org field with mixed case', async () => {
+      const contentDir = await setupContentDir(testRoot);
+      await fse.writeJson(path.join(contentDir, '.da-config.json'), { org: 'myOrg', repo: 'MyRepo' });
+      await fse.writeFile(path.join(contentDir, 'index.html'), 'changed');
+
+      const calls = [];
+      const DaClientClass = createDaClientClass({
+        onGetSource: (org, site) => calls.push({ org, site }),
+      });
+      const mod = await esmock('../../src/content/diff.cmd.js', {
+        '../../src/content/da-auth.js': { getValidToken: async () => 'token' },
+        '../../src/content/da-api.js': { DaClient: DaClientClass },
+      });
+      const Cmd = mod.default;
+      await new Cmd(makeLogger()).withDirectory(testRoot).run();
+
+      assert.ok(calls.length > 0);
+      assert.ok(calls.every((c) => c.org === 'myorg' && c.site === 'myrepo'));
+    });
   });
 });

--- a/test/content/merge.cmd.test.js
+++ b/test/content/merge.cmd.test.js
@@ -227,5 +227,47 @@ describe('MergeCommand', () => {
 
       assert.strictEqual(capturedProjectDir, testRoot);
     });
+
+    it('calls DA API with lowercase owner/repo when config uses owner field with mixed case', async () => {
+      const contentDir = await setupContentDir(testRoot);
+      await fse.writeJson(path.join(contentDir, '.da-config.json'), { owner: 'myOwner', repo: 'MyRepo' });
+      await fse.writeFile(path.join(contentDir, 'index.html'), 'changed');
+
+      const calls = [];
+      const mod = await esmock('../../src/content/merge.cmd.js', {
+        '../../src/content/da-auth.js': { getValidToken: async () => 'token' },
+        '../../src/content/da-api.js': {
+          DaClient: createDaClientClass({
+            onGetSource: (org, site) => calls.push({ org, site }),
+          }),
+        },
+      });
+      const Cmd = mod.default;
+      await new Cmd(makeLogger()).withDirectory(testRoot).run();
+
+      assert.ok(calls.length > 0);
+      assert.ok(calls.every((c) => c.org === 'myowner' && c.site === 'myrepo'));
+    });
+
+    it('calls DA API with lowercase owner/repo when config uses legacy org field with mixed case', async () => {
+      const contentDir = await setupContentDir(testRoot);
+      await fse.writeJson(path.join(contentDir, '.da-config.json'), { org: 'myOrg', repo: 'MyRepo' });
+      await fse.writeFile(path.join(contentDir, 'index.html'), 'changed');
+
+      const calls = [];
+      const mod = await esmock('../../src/content/merge.cmd.js', {
+        '../../src/content/da-auth.js': { getValidToken: async () => 'token' },
+        '../../src/content/da-api.js': {
+          DaClient: createDaClientClass({
+            onGetSource: (org, site) => calls.push({ org, site }),
+          }),
+        },
+      });
+      const Cmd = mod.default;
+      await new Cmd(makeLogger()).withDirectory(testRoot).run();
+
+      assert.ok(calls.length > 0);
+      assert.ok(calls.every((c) => c.org === 'myorg' && c.site === 'myrepo'));
+    });
   });
 });

--- a/test/content/push.cmd.test.js
+++ b/test/content/push.cmd.test.js
@@ -390,5 +390,39 @@ describe('PushCommand', () => {
         || allMsgs.includes('Would delete'),
       );
     });
+
+    it('normalizes owner/repo to lowercase when config uses owner field with mixed case', async () => {
+      const contentDir = await setupContentDir(testRoot);
+      await fse.writeJson(path.join(contentDir, '.da-config.json'), { owner: 'myOwner', repo: 'MyRepo' });
+      await fse.writeFile(path.join(contentDir, 'index.html'), 'changed');
+      await stageAllAndCommit(contentDir, 'edit');
+
+      const log = makeLogger();
+      const mod = await esmock('../../src/content/push.cmd.js', {
+        '../../src/content/da-auth.js': { getValidToken: async () => 'token' },
+        '../../src/content/da-api.js': { DaClient: createDaClientClass(), getContentType: () => 'text/html' },
+      });
+      const Cmd = mod.default;
+      await new Cmd(log).withDirectory(testRoot).run();
+
+      assert.ok(log.logs.some((l) => l.msg.includes('myowner/myrepo')));
+    });
+
+    it('normalizes owner/repo to lowercase when config uses legacy org field with mixed case', async () => {
+      const contentDir = await setupContentDir(testRoot);
+      await fse.writeJson(path.join(contentDir, '.da-config.json'), { org: 'myOrg', repo: 'MyRepo' });
+      await fse.writeFile(path.join(contentDir, 'index.html'), 'changed');
+      await stageAllAndCommit(contentDir, 'edit');
+
+      const log = makeLogger();
+      const mod = await esmock('../../src/content/push.cmd.js', {
+        '../../src/content/da-auth.js': { getValidToken: async () => 'token' },
+        '../../src/content/da-api.js': { DaClient: createDaClientClass(), getContentType: () => 'text/html' },
+      });
+      const Cmd = mod.default;
+      await new Cmd(log).withDirectory(testRoot).run();
+
+      assert.ok(log.logs.some((l) => l.msg.includes('myorg/myrepo')));
+    });
   });
 });

--- a/test/content/status.cmd.test.js
+++ b/test/content/status.cmd.test.js
@@ -88,13 +88,29 @@ describe('StatusCommand', () => {
       assert.ok(log.logs.some((l) => l.msg.includes('/index.html')));
     });
 
-    it('prints org/repo from config', async () => {
-      await setupContentDir(testRoot, 'testorg', 'testrepo');
+    it('prints org/site from config', async () => {
+      await setupContentDir(testRoot, 'testorg', 'testsite');
       const log = makeLogger();
       const cmd = new StatusCommand(log).withDirectory(testRoot);
       await cmd.run();
 
-      assert.ok(log.logs.some((l) => l.msg.includes('testorg/testrepo')));
+      assert.ok(log.logs.some((l) => l.msg.includes('testorg/testsite')));
+    });
+
+    it('normalizes owner/repo to lowercase when config uses owner field with mixed case', async () => {
+      const contentDir = await setupContentDir(testRoot);
+      await fse.writeJson(path.join(contentDir, '.da-config.json'), { owner: 'myOwner', repo: 'MyRepo' });
+      const log = makeLogger();
+      await new StatusCommand(log).withDirectory(testRoot).run();
+      assert.ok(log.logs.some((l) => l.msg.includes('myowner/myrepo')));
+    });
+
+    it('normalizes owner/repo to lowercase when config uses legacy org field with mixed case', async () => {
+      const contentDir = await setupContentDir(testRoot);
+      await fse.writeJson(path.join(contentDir, '.da-config.json'), { org: 'myOrg', repo: 'MyRepo' });
+      const log = makeLogger();
+      await new StatusCommand(log).withDirectory(testRoot).run();
+      assert.ok(log.logs.some((l) => l.msg.includes('myorg/myrepo')));
     });
 
     it('prints summary counts when changes exist', async () => {


### PR DESCRIPTION
## Summary

The previous case-sensitivity fix introduced `owner`/`repo` keys in `.da-config.json`, conflicting with da.live's own `org`/`site` terminology and leaving push/diff/merge/status commands with scattered, inconsistent config reads.

- **`readContentConfig()`** added to `content-shared.js` — single function that reads `.da-config.json`, normalizes to lowercase, and handles field migration: `org`/`site` take priority; legacy `owner`/`repo` (written by the now-fixed clone) are accepted as fallback
- **`clone.cmd.js`**: GitHub `owner`/`repo` are mapped to da.live `org`/`site` immediately after URL parsing; config now stores `{ org, site, rootPath }`
- **`push/diff/merge/status.cmd.js`**: replace individual `fse.readJson` + normalization blocks with a single `readContentConfig()` call; all variables renamed to `org`/`site`
- **`da-api.js`**: second parameter renamed from `repo` to `site` across all methods
- **Tests**: `setupContentDir` writes `{ org, site }`; mock callbacks use `org`/`site`; 6 new unit tests for `readContentConfig()` covering current format, legacy fallback, priority, and case normalization; 8 case-sensitivity tests across all 4 commands

## Test plan

- [ ] All 135 content tests pass (`CloneCommand`, `StatusCommand`, `DiffCommand`, `MergeCommand`, `PushCommand`, `DaClient`, `readContentConfig`)
- [ ] `npm run lint` clean
- [ ] Existing configs with legacy `{ owner, repo }` keys continue to work (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)