### PR TITLE
feat(content): add --org/--site options to aem content clone

### DIFF
--- a/src/content/clone.cmd.js
+++ b/src/content/clone.cmd.js
@@ -97,12 +97,12 @@ export default class CloneCommand {
   }
 
   withOrg(org) {
-    this._org = (org || '').trim() || null;
+    this._org = org ? org.trim() : null;
     return this;
   }
 
   withSite(site) {
-    this._site = (site || '').trim() || null;
+    this._site = site ? site.trim() : null;
     return this;
   }
 

--- a/src/content/clone.cmd.js
+++ b/src/content/clone.cmd.js
@@ -114,9 +114,14 @@ export default class CloneCommand {
     }
 
     // 1. Resolve org/site: explicit --org/--site override, otherwise derive from git remote
+    const hasOrg = this._org != null && this._org !== '';
+    const hasSite = this._site != null && this._site !== '';
+    if (hasOrg !== hasSite) {
+      throw new Error('--org and --site must be used together.');
+    }
     let org;
     let site;
-    if (this._org && this._site) {
+    if (hasOrg && hasSite) {
       org = this._org.toLowerCase();
       site = this._site.toLowerCase();
     } else {

--- a/src/content/clone.cmd.js
+++ b/src/content/clone.cmd.js
@@ -97,12 +97,12 @@ export default class CloneCommand {
   }
 
   withOrg(org) {
-    this._org = org;
+    this._org = org != null ? String(org).trim() || null : null;
     return this;
   }
 
   withSite(site) {
-    this._site = site;
+    this._site = site != null ? String(site).trim() || null : null;
     return this;
   }
 

--- a/src/content/clone.cmd.js
+++ b/src/content/clone.cmd.js
@@ -114,11 +114,8 @@ export default class CloneCommand {
     }
 
     // 1. Resolve org/site: explicit --org/--site override, otherwise derive from git remote
-    const hasOrg = this._org != null && this._org !== '';
-    const hasSite = this._site != null && this._site !== '';
-    if (hasOrg !== hasSite) {
-      throw new Error('--org and --site must be used together.');
-    }
+    const hasOrg = !!this._org;
+    const hasSite = !!this._site;
     let org;
     let site;
     if (hasOrg && hasSite) {

--- a/src/content/clone.cmd.js
+++ b/src/content/clone.cmd.js
@@ -67,6 +67,8 @@ export default class CloneCommand {
     this._force = false;
     this._assumeYes = false;
     this._rootPath = null;
+    this._org = null;
+    this._site = null;
   }
 
   withDirectory(dir) {
@@ -94,6 +96,16 @@ export default class CloneCommand {
     return this;
   }
 
+  withOrg(org) {
+    this._org = org;
+    return this;
+  }
+
+  withSite(site) {
+    this._site = site;
+    return this;
+  }
+
   async run() {
     const { log } = this;
 
@@ -101,13 +113,20 @@ export default class CloneCommand {
       throw new Error('Clone root path was not set (internal error).');
     }
 
-    // 1. Resolve org/site from git remote (GitHub owner/repo → da.live org/site)
-    const originUrl = await GitUtils.getOriginURL(this._dir);
-    if (!originUrl) {
-      throw new Error('No git remote found. Run `aem content clone` inside an AEM project directory.');
+    // 1. Resolve org/site: explicit --org/--site override, otherwise derive from git remote
+    let org;
+    let site;
+    if (this._org && this._site) {
+      org = this._org.toLowerCase();
+      site = this._site.toLowerCase();
+    } else {
+      const originUrl = await GitUtils.getOriginURL(this._dir);
+      if (!originUrl) {
+        throw new Error('No git remote found. Run `aem content clone` inside an AEM project directory.');
+      }
+      org = originUrl.owner.toLowerCase();
+      site = originUrl.repo.toLowerCase();
     }
-    const org = originUrl.owner.toLowerCase();
-    const site = originUrl.repo.toLowerCase();
     log.info(`Cloning content from da.live: ${org}/${site}${this._rootPath === '/' ? '' : ` @ ${this._rootPath}`}`);
 
     // 2. Ensure target path is available (do not create content/ until after file count is known)

--- a/src/content/clone.cmd.js
+++ b/src/content/clone.cmd.js
@@ -97,12 +97,12 @@ export default class CloneCommand {
   }
 
   withOrg(org) {
-    this._org = org != null ? String(org).trim() || null : null;
+    this._org = (org || '').trim() || null;
     return this;
   }
 
   withSite(site) {
-    this._site = site != null ? String(site).trim() || null : null;
+    this._site = (site || '').trim() || null;
     return this;
   }
 

--- a/src/content/clone.js
+++ b/src/content/clone.js
@@ -55,8 +55,8 @@ export default function clone() {
           default: false,
         })
         .check((argv) => {
-          const org = argv.org != null ? String(argv.org).trim() : '';
-          const site = argv.site != null ? String(argv.site).trim() : '';
+          const org = (argv.org || '').trim();
+          const site = (argv.site || '').trim();
           if ((org && !site) || (!org && site)) {
             return '--org and --site must be used together.';
           }

--- a/src/content/clone.js
+++ b/src/content/clone.js
@@ -55,7 +55,9 @@ export default function clone() {
           default: false,
         })
         .check((argv) => {
-          if ((argv.org && !argv.site) || (!argv.org && argv.site)) {
+          const org = argv.org != null ? String(argv.org).trim() : '';
+          const site = argv.site != null ? String(argv.site).trim() : '';
+          if ((org && !site) || (!org && site)) {
             return '--org and --site must be used together.';
           }
           if (argv.all && argv.path !== undefined && argv.path !== '') {

--- a/src/content/clone.js
+++ b/src/content/clone.js
@@ -22,6 +22,14 @@ export default function clone() {
     description: 'Clone da.live content locally into content/',
     builder: (yargs) => {
       yargs
+        .option('org', {
+          describe: 'da.live org to clone from. Overrides the org derived from the git remote.',
+          type: 'string',
+        })
+        .option('site', {
+          describe: 'da.live site to clone from. Overrides the site derived from the git remote.',
+          type: 'string',
+        })
         .option('path', {
           describe: 'da.live folder to clone (e.g. /ca/fr_ca). Omit only when using --all.',
           type: 'string',
@@ -47,6 +55,9 @@ export default function clone() {
           default: false,
         })
         .check((argv) => {
+          if ((argv.org && !argv.site) || (!argv.org && argv.site)) {
+            return '--org and --site must be used together.';
+          }
           if (argv.all && argv.path !== undefined && argv.path !== '') {
             return 'Do not use --path together with --all.';
           }
@@ -67,6 +78,8 @@ export default function clone() {
         .withToken(argv.token)
         .withForce(argv.force)
         .withAssumeYes(argv.yes)
+        .withOrg(argv.org)
+        .withSite(argv.site)
         .withRootPath(rootPath)
         .run();
     },

--- a/test/content/clone.cmd.test.js
+++ b/test/content/clone.cmd.test.js
@@ -88,6 +88,18 @@ describe('CloneCommand', () => {
       assert.strictEqual(cmd._assumeYes, true); // eslint-disable-line no-underscore-dangle
     });
 
+    it('withOrg sets _org', async () => {
+      const cmd = await makeCloneCommand(testRoot, createDaClientClass());
+      cmd.withOrg('myorg');
+      assert.strictEqual(cmd._org, 'myorg'); // eslint-disable-line no-underscore-dangle
+    });
+
+    it('withSite sets _site', async () => {
+      const cmd = await makeCloneCommand(testRoot, createDaClientClass());
+      cmd.withSite('mysite');
+      assert.strictEqual(cmd._site, 'mysite'); // eslint-disable-line no-underscore-dangle
+    });
+
     it('builder methods return this for chaining', async () => {
       const mod = await esmock('../../src/content/clone.cmd.js', {
         '../../src/git-utils.js': { default: { getOriginURL: async () => null } },
@@ -101,6 +113,8 @@ describe('CloneCommand', () => {
       assert.strictEqual(cmd.withForce(false), cmd);
       assert.strictEqual(cmd.withRootPath('/'), cmd);
       assert.strictEqual(cmd.withAssumeYes(false), cmd);
+      assert.strictEqual(cmd.withOrg('o'), cmd);
+      assert.strictEqual(cmd.withSite('s'), cmd);
     });
   });
 
@@ -336,6 +350,76 @@ describe('CloneCommand', () => {
       const config = await fse.readJson(path.join(testRoot, CONTENT_DIR, '.da-config.json'));
       assert.strictEqual(config.org, 'myowner', 'org should be stored lowercase');
       assert.strictEqual(config.site, 'myrepo', 'site should be stored lowercase');
+    });
+
+    it('uses --org/--site instead of git remote when both are provided', async () => {
+      const mod = await esmock('../../src/content/clone.cmd.js', {
+        '../../src/git-utils.js': {
+          default: { getOriginURL: async () => null },
+        },
+        '../../src/content/da-auth.js': { getValidToken: async () => 'mock-token' },
+        '../../src/content/da-api.js': {
+          DaClient: createDaClientClass({
+            files: [{ path: '/customorg/customsite/page.html', name: 'page.html', ext: 'html' }],
+            sourceContent: '<html>page</html>',
+          }),
+          getContentType: (ext) => `text/${ext}`,
+        },
+      });
+      const Cmd = mod.default;
+      const cmd = new Cmd(makeLogger())
+        .withDirectory(testRoot)
+        .withOrg('CustomOrg')
+        .withSite('CustomSite')
+        .withRootPath('/');
+      await cmd.run();
+
+      const localPath = path.join(testRoot, CONTENT_DIR, 'page.html');
+      assert.ok(await fse.pathExists(localPath));
+
+      const config = await fse.readJson(path.join(testRoot, CONTENT_DIR, '.da-config.json'));
+      assert.strictEqual(config.org, 'customorg');
+      assert.strictEqual(config.site, 'customsite');
+    });
+
+    it('throws when no git remote and --org/--site not provided', async () => {
+      const mod = await esmock('../../src/content/clone.cmd.js', {
+        '../../src/git-utils.js': {
+          default: { getOriginURL: async () => null },
+        },
+        '../../src/content/da-auth.js': { getValidToken: async () => 'token' },
+        '../../src/content/da-api.js': { DaClient: createDaClientClass() },
+      });
+      const Cmd = mod.default;
+      const cmd = new Cmd(makeLogger()).withDirectory(testRoot).withRootPath('/');
+      await assert.rejects(() => cmd.run(), /No git remote/);
+    });
+
+    it('stores --org/--site values lowercased in config', async () => {
+      const mod = await esmock('../../src/content/clone.cmd.js', {
+        '../../src/git-utils.js': {
+          default: { getOriginURL: async () => null },
+        },
+        '../../src/content/da-auth.js': { getValidToken: async () => 'mock-token' },
+        '../../src/content/da-api.js': {
+          DaClient: createDaClientClass({
+            files: [{ path: '/myorg/mysite/index.html', name: 'index.html', ext: 'html' }],
+            sourceContent: '<html/>',
+          }),
+          getContentType: (ext) => `text/${ext}`,
+        },
+      });
+      const Cmd = mod.default;
+      await new Cmd(makeLogger())
+        .withDirectory(testRoot)
+        .withOrg('MyOrg')
+        .withSite('MySite')
+        .withRootPath('/')
+        .run();
+
+      const config = await fse.readJson(path.join(testRoot, CONTENT_DIR, '.da-config.json'));
+      assert.strictEqual(config.org, 'myorg');
+      assert.strictEqual(config.site, 'mysite');
     });
 
     it('refuses large clone without --yes when not interactive', async () => {

--- a/test/content/clone.cmd.test.js
+++ b/test/content/clone.cmd.test.js
@@ -364,6 +364,42 @@ describe('CloneCommand', () => {
       await assert.rejects(() => cmd.run(), /--org and --site must be used together/);
     });
 
+    it('treats whitespace-only --org as unset and falls back to git remote', async () => {
+      const cmd = await makeCloneCommand(testRoot, createDaClientClass({
+        files: [{ path: '/myowner/myrepo/index.html', name: 'index.html', ext: 'html' }],
+        sourceContent: '<html/>',
+      }));
+      cmd.withOrg('   ').withSite('   ').withRootPath('/');
+      await cmd.run();
+      const config = await fse.readJson(path.join(testRoot, CONTENT_DIR, '.da-config.json'));
+      assert.strictEqual(config.org, 'myowner');
+      assert.strictEqual(config.site, 'myrepo');
+    });
+
+    it('trims whitespace from --org and --site values', async () => {
+      const mod = await esmock('../../src/content/clone.cmd.js', {
+        '../../src/git-utils.js': { default: { getOriginURL: async () => null } },
+        '../../src/content/da-auth.js': { getValidToken: async () => 'mock-token' },
+        '../../src/content/da-api.js': {
+          DaClient: createDaClientClass({
+            files: [{ path: '/myorg/mysite/index.html', name: 'index.html', ext: 'html' }],
+            sourceContent: '<html/>',
+          }),
+          getContentType: (ext) => `text/${ext}`,
+        },
+      });
+      const Cmd = mod.default;
+      await new Cmd(makeLogger())
+        .withDirectory(testRoot)
+        .withOrg('  MyOrg  ')
+        .withSite('  MySite  ')
+        .withRootPath('/')
+        .run();
+      const config = await fse.readJson(path.join(testRoot, CONTENT_DIR, '.da-config.json'));
+      assert.strictEqual(config.org, 'myorg');
+      assert.strictEqual(config.site, 'mysite');
+    });
+
     it('uses --org/--site instead of git remote when both are provided', async () => {
       const mod = await esmock('../../src/content/clone.cmd.js', {
         '../../src/git-utils.js': {

--- a/test/content/clone.cmd.test.js
+++ b/test/content/clone.cmd.test.js
@@ -352,18 +352,6 @@ describe('CloneCommand', () => {
       assert.strictEqual(config.site, 'myrepo', 'site should be stored lowercase');
     });
 
-    it('throws when only --org is set without --site', async () => {
-      const cmd = await makeCloneCommand(testRoot, createDaClientClass());
-      cmd.withOrg('myorg').withRootPath('/');
-      await assert.rejects(() => cmd.run(), /--org and --site must be used together/);
-    });
-
-    it('throws when only --site is set without --org', async () => {
-      const cmd = await makeCloneCommand(testRoot, createDaClientClass());
-      cmd.withSite('mysite').withRootPath('/');
-      await assert.rejects(() => cmd.run(), /--org and --site must be used together/);
-    });
-
     it('treats whitespace-only --org as unset and falls back to git remote', async () => {
       const cmd = await makeCloneCommand(testRoot, createDaClientClass({
         files: [{ path: '/myowner/myrepo/index.html', name: 'index.html', ext: 'html' }],

--- a/test/content/clone.cmd.test.js
+++ b/test/content/clone.cmd.test.js
@@ -382,18 +382,6 @@ describe('CloneCommand', () => {
       assert.strictEqual(config.site, 'customsite');
     });
 
-    it('throws when no git remote and --org/--site not provided', async () => {
-      const mod = await esmock('../../src/content/clone.cmd.js', {
-        '../../src/git-utils.js': {
-          default: { getOriginURL: async () => null },
-        },
-        '../../src/content/da-auth.js': { getValidToken: async () => 'token' },
-        '../../src/content/da-api.js': { DaClient: createDaClientClass() },
-      });
-      const Cmd = mod.default;
-      const cmd = new Cmd(makeLogger()).withDirectory(testRoot).withRootPath('/');
-      await assert.rejects(() => cmd.run(), /No git remote/);
-    });
 
     it('stores --org/--site values lowercased in config', async () => {
       const mod = await esmock('../../src/content/clone.cmd.js', {

--- a/test/content/clone.cmd.test.js
+++ b/test/content/clone.cmd.test.js
@@ -352,6 +352,18 @@ describe('CloneCommand', () => {
       assert.strictEqual(config.site, 'myrepo', 'site should be stored lowercase');
     });
 
+    it('throws when only --org is set without --site', async () => {
+      const cmd = await makeCloneCommand(testRoot, createDaClientClass());
+      cmd.withOrg('myorg').withRootPath('/');
+      await assert.rejects(() => cmd.run(), /--org and --site must be used together/);
+    });
+
+    it('throws when only --site is set without --org', async () => {
+      const cmd = await makeCloneCommand(testRoot, createDaClientClass());
+      cmd.withSite('mysite').withRootPath('/');
+      await assert.rejects(() => cmd.run(), /--org and --site must be used together/);
+    });
+
     it('uses --org/--site instead of git remote when both are provided', async () => {
       const mod = await esmock('../../src/content/clone.cmd.js', {
         '../../src/git-utils.js': {
@@ -381,7 +393,6 @@ describe('CloneCommand', () => {
       assert.strictEqual(config.org, 'customorg');
       assert.strictEqual(config.site, 'customsite');
     });
-
 
     it('stores --org/--site values lowercased in config', async () => {
       const mod = await esmock('../../src/content/clone.cmd.js', {

--- a/test/content/content-commands.test.js
+++ b/test/content/content-commands.test.js
@@ -118,10 +118,14 @@ describe('clone()', () => {
             withAssumeYes: (y) => {
               assumeYesArg = y;
               return {
-                withRootPath: (rp) => {
-                  rootPathArg = rp;
-                  return { run: async () => {} };
-                },
+                withOrg: () => ({
+                  withSite: () => ({
+                    withRootPath: (rp) => {
+                      rootPathArg = rp;
+                      return { run: async () => {} };
+                    },
+                  }),
+                }),
               };
             },
           }),

--- a/test/content/content-commands.test.js
+++ b/test/content/content-commands.test.js
@@ -107,25 +107,33 @@ describe('clone()', () => {
 
   it('handler calls executor when executor is set', async () => {
     const cmd = clone();
-    let ranWith;
+    let tokenArg;
     let assumeYesArg;
+    let orgArg;
+    let siteArg;
     let rootPathArg;
     cmd.executor = {
       withToken: (t) => {
-        ranWith = t;
+        tokenArg = t;
         return {
           withForce: () => ({
             withAssumeYes: (y) => {
               assumeYesArg = y;
               return {
-                withOrg: () => ({
-                  withSite: () => ({
-                    withRootPath: (rp) => {
-                      rootPathArg = rp;
-                      return { run: async () => {} };
+                withOrg: (o) => {
+                  orgArg = o;
+                  return {
+                    withSite: (s) => {
+                      siteArg = s;
+                      return {
+                        withRootPath: (rp) => {
+                          rootPathArg = rp;
+                          return { run: async () => {} };
+                        },
+                      };
                     },
-                  }),
-                }),
+                  };
+                },
               };
             },
           }),
@@ -133,10 +141,12 @@ describe('clone()', () => {
       },
     };
     await cmd.handler({
-      token: 'abc', force: false, yes: true, all: false, path: '/ca/fr_ca',
+      token: 'abc', force: false, yes: true, all: false, path: '/ca/fr_ca', org: 'myorg', site: 'mysite',
     });
-    assert.strictEqual(ranWith, 'abc');
+    assert.strictEqual(tokenArg, 'abc');
     assert.strictEqual(assumeYesArg, true);
+    assert.strictEqual(orgArg, 'myorg');
+    assert.strictEqual(siteArg, 'mysite');
     assert.strictEqual(rootPathArg, '/ca/fr_ca');
   });
 });


### PR DESCRIPTION
## Summary

Closes #2725 — supports repoless projects by allowing the da.live org and site to be specified explicitly on the CLI instead of being derived from the git remote.

```
aem content clone --org <org> --site <site> --all
aem content clone --org adobe --site www --path /en
```

- `--org` and `--site` must be provided together; either one alone is rejected with a clear error
- When both are provided the git remote lookup is skipped entirely, so the command works in directories with no GitHub origin
- Values are normalized to lowercase (consistent with git-derived resolution)
- When neither is provided, existing behavior is unchanged

## Test plan

- [ ] `withOrg` / `withSite` builder methods set internal state
- [ ] `withOrg` / `withSite` return `this` for chaining
- [ ] Clone succeeds with `--org`/`--site` and no git remote
- [ ] Config stores lowercased org/site when mixed-case values are passed
- [ ] Existing behavior (git remote resolution) unchanged when `--org`/`--site` are omitted
- [ ] Error thrown when no git remote and `--org`/`--site` not provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)