### PR TITLE
fix(up): handle non-parseable SSH git remote origin gracefully

### DIFF
--- a/src/up.cmd.js
+++ b/src/up.cmd.js
@@ -139,11 +139,32 @@ export default class UpCommand extends AbstractServerCommand {
     });
 
     const ref = await GitUtils.getBranch(this.directory);
-    this._gitUrl = await GitUtils.getOriginURL(this.directory, { ref });
-    if (!this._gitUrl) {
-      throw Error('No git remote found. Make sure you have a remote "origin" configured.');
+    let gitUrlError;
+    try {
+      this._gitUrl = await GitUtils.getOriginURL(this.directory, { ref });
+    } catch (e) {
+      gitUrlError = e;
     }
-    await this.initUrl(this._gitUrl, ref);
+
+    if (!this._gitUrl) {
+      if (gitUrlError) {
+        if (this._originalUrl && !this._originalUrl.includes('{{')) {
+          this.log.warn(chalk`Could not parse git remote origin URL: {yellow ${gitUrlError.message}}`);
+          this.log.warn(chalk`Continuing with the provided {cyan --url} value.`);
+          this._url = this._originalUrl;
+        } else {
+          this.log.error(chalk`Could not parse git remote origin URL: {yellow ${gitUrlError.message}}`);
+          this.log.error('The git remote origin uses an SSH URL format that cannot be automatically resolved.');
+          this.log.error(chalk`Please specify the content origin URL using the {cyan --url} option:`);
+          this.log.error(chalk`  {cyan aem up --url https://main--<repo>--<owner>.aem.page}`);
+          throw Error('Invalid git remote origin URL. Use --url to specify the content origin.');
+        }
+      } else {
+        throw Error('No git remote found. Make sure you have a remote "origin" configured.');
+      }
+    } else {
+      await this.initUrl(this._gitUrl, ref);
+    }
     this._project.withProxyUrl(this._url);
     const { site, org } = this.extractSiteAndOrg(this._url);
     if (site && org) {

--- a/test/up-cmd.test.js
+++ b/test/up-cmd.test.js
@@ -855,4 +855,53 @@ describe('Integration test for up command with cache', function suite() {
     // eslint-disable-next-line no-underscore-dangle
     assert.strictEqual(cmd._url, 'https://custom.domain.com', 'User-provided --pagesUrl should be preserved during git reconfiguration');
   });
+
+  it('shows helpful error when git remote origin uses non-parseable SSH format', async () => {
+    initGit(testDir, 'user@example.ghe.com:ACMEGROUP/acme-eds.git');
+    const cmd = new UpCommand()
+      .withLiveReload(false)
+      .withDirectory(testDir);
+
+    try {
+      await cmd.init();
+      assert.fail('Should have thrown an error for non-parseable SSH origin');
+    } catch (e) {
+      assert(
+        e.message.includes('Invalid git remote origin URL'),
+        `Expected SSH URL error, got: ${e.message}`,
+      );
+    }
+  });
+
+  it('starts successfully when non-parseable SSH origin is paired with --url', async () => {
+    initGit(testDir, 'user@example.ghe.com:ACMEGROUP/acme-eds.git');
+    const cmd = new UpCommand()
+      .withLiveReload(false)
+      .withDirectory(testDir)
+      .withHttpPort(0)
+      .withUrl('https://main--acme-eds--acmegroup.aem.page');
+
+    await new Promise((resolve, reject) => {
+      let error = null;
+      cmd
+        .on('started', async () => {
+          try {
+            // eslint-disable-next-line no-underscore-dangle
+            assert.strictEqual(cmd._url, 'https://main--acme-eds--acmegroup.aem.page');
+          } catch (e) {
+            error = e;
+          }
+          await cmd.stop();
+        })
+        .on('stopped', () => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        })
+        .run()
+        .catch(reject);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- When the git remote origin uses a non-`git@` SSH URL format (e.g. `user@example.ghe.com:ACMEGROUP/racq-eds.git`), `GitUrl` cannot parse it and throws `Invalid URL`, which previously crashed `aem up` with no useful message
- If `--url` is **not** provided: a clear error now explains the SSH format limitation and suggests using `--url`
- If a concrete `--url` is provided: the origin parse error is suppressed and startup continues normally using the provided URL

## Test plan

- [x] `shows helpful error when git remote origin uses non-parseable SSH format` — verifies the friendly error message and early exit
- [x] `starts successfully when non-parseable SSH origin is paired with --url` — verifies the server starts and `_url` is set correctly from the provided `--url`
- [x] Full test suite passes (`npm test` exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)