### PR TITLE
fix: inject hlx:proxyUrl meta for local content/ pages

### DIFF
--- a/src/server/HelixServer.js
+++ b/src/server/HelixServer.js
@@ -503,6 +503,13 @@ export class HelixServer extends BaseServer {
                 htmlContent = htmlContent.replace(/<\/head>/i, `${metaTagsHtml}</head>`);
               }
             }
+            const proxyPageUrl = new URL(ctx.url, proxyUrl);
+            for (const [key, value] of proxyUrl.searchParams.entries()) {
+              proxyPageUrl.searchParams.append(key, value);
+            }
+            htmlContent = utils.injectMeta(htmlContent, {
+              'hlx:proxyUrl': proxyPageUrl.href,
+            });
             if (liveReload) {
               htmlContent = utils.injectLiveReloadScript(htmlContent, this);
               liveReload.registerFile(ctx.requestId, contentFilePath);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1266,6 +1266,7 @@ describe('Helix Server', () => {
         assert.ok(body.includes('content="/ca/fr_ca/nav/nav"'));
         assert.ok(body.includes('name="footer"'));
         assert.ok(body.includes('content="/ca/fr_ca/footer/footer"'));
+        assert.ok(body.includes('<meta property="hlx:proxyUrl" content="http://main--foo--bar.aem.page/ca/fr_ca/recipes/chicken">'));
       } finally {
         await project.stop();
       }


### PR DESCRIPTION
## Summary
- `aem up` served pages from a local `content/` checkout without the `hlx:proxyUrl` meta tag that the proxy path already injects, so the sidekick couldn't resolve the edit source for those pages.
- Injects `hlx:proxyUrl` (pointing at the equivalent proxy URL) into HTML served from `content/`, matching what already happens for proxied responses.

## Test plan
- [x] Added regression test in `test/server.test.js` (content/ serving), confirmed it fails without the fix and passes with it
- [x] `npm run lint`
- [x] `npx mocha test/server.test.js` (pre-existing unrelated flake around port 3000 reuse, reproduces on `main` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)